### PR TITLE
Add configure flags to allow setting setuid/setcaps

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,15 @@ bin_PROGRAMS = bwrap
 bwrap_srcpath := $(srcdir)
 include Makefile-bwrap.am
 
-test-setuid: bwrap
-	sudo chown root bwrap
-	sudo sudo chmod u+s bwrap
-
-test-setcaps: bwrap
-	sudo setcap "cap_sys_admin+ep cap_sys_chroot+ep" bwrap
+install-exec-hook:
+if PRIV_MODE_SETUID
+	$(SUDO_BIN) chown root $(DESTDIR)$(bindir)/bwrap
+	$(SUDO_BIN) chmod u+s $(DESTDIR)$(bindir)/bwrap
+else
+if PRIV_MODE_FILECAPS
+	$(SUDO_BIN) setcap cap_sys_admin,cap_sys_chroot+ep $(DESTDIR)$(bindir)/bwrap
+endif
+endif
 
 include Makefile-docs.am
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,20 @@ fi
 changequote([,])dnl
 AC_SUBST(WARN_CFLAGS)
 
+AC_ARG_WITH(priv-mode,
+            AS_HELP_STRING([--with-priv-mode=setuid/caps/none],
+                           [How to set privilege-raising during make install)]),
+            [],
+            [with_priv_mode="none"])
+
+AM_CONDITIONAL(PRIV_MODE_FILECAPS, test "x$with_priv_mode" = "xcaps")
+AM_CONDITIONAL(PRIV_MODE_SETUID, test "x$with_priv_mode" = "xsetuid")
+
+AC_ARG_ENABLE(sudo,
+              AS_HELP_STRING([--enable-sudo],[Use sudo to set privileged mode on binaries during install (only needed if --with-priv-mode used)]),
+              [SUDO_BIN="sudo"], [SUDO_BIN=""])
+AC_SUBST([SUDO_BIN])
+
 AC_CONFIG_FILES([
 Makefile
 ])


### PR DESCRIPTION
With this you can e.g. :
./configure --enable-sudo --with-priv-mode=setcaps
make
make install

and it will ask you for sudo password and then make the final binary
have the right capabilities set.

This is not needed when setting such persmissions in e.g. a spec file, but
it is useful for developers building bubblewrap.