### PR TITLE
build: Add SELinux and priv mode to build configuration output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,5 +81,7 @@ echo "
     ===================
 
     man pages (xsltproc):                         $enable_man
+    SELinux:                                      $have_selinux
+    setuid mode on make install:                  $with_priv_mode
     mysteriously satisfying to pop:               yes"
 echo ""


### PR DESCRIPTION
Greater visibility for these is useful.  (Alternatively, autoconf
could be less verbose but I'm assuming that's not going to happen
before the sun explodes).