### PR TITLE
[merged] Use 64bit capability syscalls

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -345,11 +345,8 @@ do_init (int event_fd, pid_t initial_pid)
 static void
 acquire_caps (void)
 {
-  struct __user_cap_header_struct hdr;
-  struct __user_cap_data_struct data[2];
-
-  memset (&hdr, 0, sizeof(hdr));
-  hdr.version = _LINUX_CAPABILITY_VERSION_3;
+  struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+  struct __user_cap_data_struct data[2] = { { 0 } };
 
   if (capget (&hdr, data)  < 0)
     die_with_error ("capget failed");
@@ -373,9 +370,6 @@ acquire_caps (void)
 
   if (is_privileged)
     {
-      memset (&hdr, 0, sizeof(hdr));
-      hdr.version = _LINUX_CAPABILITY_VERSION_3;
-
       /* Drop all non-require capabilities */
       data[0].effective = REQUIRED_CAPS_0;
       data[0].permitted = REQUIRED_CAPS_0;
@@ -396,20 +390,11 @@ acquire_caps (void)
 static void
 drop_caps (void)
 {
-  struct __user_cap_header_struct hdr;
-  struct __user_cap_data_struct data[2];
+  struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+  struct __user_cap_data_struct data[2] = { { 0 } };
 
   if (!is_privileged)
     return;
-
-  memset (&hdr, 0, sizeof(hdr));
-  hdr.version = _LINUX_CAPABILITY_VERSION_3;
-  data[0].effective = 0;
-  data[0].permitted = 0;
-  data[0].inheritable = 0;
-  data[1].effective = 0;
-  data[1].permitted = 0;
-  data[1].inheritable = 0;
 
   if (capset (&hdr, data) < 0)
     die_with_error ("capset failed");

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -337,22 +337,27 @@ do_init (int event_fd, pid_t initial_pid)
   return initial_exit_status;
 }
 
-#define REQUIRED_CAPS (CAP_TO_MASK(CAP_SYS_ADMIN)|CAP_TO_MASK(CAP_SYS_CHROOT))
+/* low 32bit caps needed */
+#define REQUIRED_CAPS_0 (CAP_TO_MASK(CAP_SYS_ADMIN)|CAP_TO_MASK(CAP_SYS_CHROOT))
+/* high 32bit caps needed */
+#define REQUIRED_CAPS_1 0
 
 static void
 acquire_caps (void)
 {
   struct __user_cap_header_struct hdr;
-  struct __user_cap_data_struct data;
+  struct __user_cap_data_struct data[2];
 
   memset (&hdr, 0, sizeof(hdr));
-  hdr.version = _LINUX_CAPABILITY_VERSION;
+  hdr.version = _LINUX_CAPABILITY_VERSION_3;
 
-  if (capget (&hdr, &data)  < 0)
+  if (capget (&hdr, data)  < 0)
     die_with_error ("capget failed");
 
-  if (((data.effective & REQUIRED_CAPS) == REQUIRED_CAPS) &&
-      ((data.permitted & REQUIRED_CAPS) == REQUIRED_CAPS))
+  if (((data[0].effective & REQUIRED_CAPS_0) == REQUIRED_CAPS_0) &&
+      ((data[0].permitted & REQUIRED_CAPS_0) == REQUIRED_CAPS_0) &&
+      ((data[1].effective & REQUIRED_CAPS_1) == REQUIRED_CAPS_1) &&
+      ((data[1].permitted & REQUIRED_CAPS_1) == REQUIRED_CAPS_1))
     is_privileged = TRUE;
 
   if (getuid () != geteuid ())
@@ -369,13 +374,16 @@ acquire_caps (void)
   if (is_privileged)
     {
       memset (&hdr, 0, sizeof(hdr));
-      hdr.version = _LINUX_CAPABILITY_VERSION;
+      hdr.version = _LINUX_CAPABILITY_VERSION_3;
 
       /* Drop all non-require capabilities */
-      data.effective = REQUIRED_CAPS;
-      data.permitted = REQUIRED_CAPS;
-      data.inheritable = 0;
-      if (capset (&hdr, &data) < 0)
+      data[0].effective = REQUIRED_CAPS_0;
+      data[0].permitted = REQUIRED_CAPS_0;
+      data[0].inheritable = 0;
+      data[1].effective = REQUIRED_CAPS_1;
+      data[1].permitted = REQUIRED_CAPS_1;
+      data[1].inheritable = 0;
+      if (capset (&hdr, data) < 0)
         die_with_error ("capset failed");
     }
   /* Else, we try unprivileged user namespaces */
@@ -389,18 +397,21 @@ static void
 drop_caps (void)
 {
   struct __user_cap_header_struct hdr;
-  struct __user_cap_data_struct data;
+  struct __user_cap_data_struct data[2];
 
   if (!is_privileged)
     return;
 
   memset (&hdr, 0, sizeof(hdr));
-  hdr.version = _LINUX_CAPABILITY_VERSION;
-  data.effective = 0;
-  data.permitted = 0;
-  data.inheritable = 0;
+  hdr.version = _LINUX_CAPABILITY_VERSION_3;
+  data[0].effective = 0;
+  data[0].permitted = 0;
+  data[0].inheritable = 0;
+  data[1].effective = 0;
+  data[1].permitted = 0;
+  data[1].inheritable = 0;
 
-  if (capset (&hdr, &data) < 0)
+  if (capset (&hdr, data) < 0)
     die_with_error ("capset failed");
 }
 


### PR DESCRIPTION
The rawhide kernel has started to warn about applications using 32bit
capabilities calls. We don't actually need more than 32 bits, but
lets use the 64bit APIs anyway to stay safe.