### PR TITLE
[merged] Ignore errors when writing to event_fd in a better way

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -315,15 +315,18 @@ do_init (int event_fd, pid_t initial_pid)
       int status;
 
       child = wait (&status);
-      if (child == initial_pid)
+      if (child == initial_pid && event_fd != -1)
         {
           uint64_t val;
+          int res UNUSED;
 
           if (WIFEXITED (status))
             initial_exit_status = WEXITSTATUS(status);
 
           val = initial_exit_status + 1;
-          (void) write (event_fd, &val, 8);
+          res = write (event_fd, &val, 8);
+          /* Ignore res, if e.g. the parent died and closed event_fd
+             we don't want to error out here */
         }
 
       if (child == -1 && errno != EINTR)

--- a/utils.h
+++ b/utils.h
@@ -37,6 +37,8 @@
 #define __debug__(x)
 #endif
 
+#define UNUSED __attribute__((__unused__))
+
 #define N_ELEMENTS(arr)		(sizeof (arr) / sizeof ((arr)[0]))
 
 #define TRUE 1


### PR DESCRIPTION
GCC was failing this because write is marked warn_unused_result.
Assigning it to a attribute unused variable is apparently "better"
than casting it to void...

Also, we avoid taking this path at all if event_fd is -1.