### PR TITLE
[merged] Require CAP_NET_ADMIN

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ if PRIV_MODE_SETUID
 	$(SUDO_BIN) chmod u+s $(DESTDIR)$(bindir)/bwrap
 else
 if PRIV_MODE_FILECAPS
-	$(SUDO_BIN) setcap cap_sys_admin,cap_sys_chroot+ep $(DESTDIR)$(bindir)/bwrap
+	$(SUDO_BIN) setcap cap_sys_admin,cap_net_admin,cap_sys_chroot+ep $(DESTDIR)$(bindir)/bwrap
 endif
 endif
 

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -341,7 +341,7 @@ do_init (int event_fd, pid_t initial_pid)
 }
 
 /* low 32bit caps needed */
-#define REQUIRED_CAPS_0 (CAP_TO_MASK(CAP_SYS_ADMIN)|CAP_TO_MASK(CAP_SYS_CHROOT))
+#define REQUIRED_CAPS_0 (CAP_TO_MASK(CAP_SYS_ADMIN)|CAP_TO_MASK(CAP_SYS_CHROOT)|CAP_TO_MASK(CAP_NET_ADMIN))
 /* high 32bit caps needed */
 #define REQUIRED_CAPS_1 0
 

--- a/packaging/bubblewrap.spec
+++ b/packaging/bubblewrap.spec
@@ -38,7 +38,7 @@ find $RPM_BUILD_ROOT -name '*.la' -delete
 %doc README.md
 %{_datadir}/bash-completion/completions/bwrap
 %if (0%{?rhel} != 0 && 0%{?rhel} <= 7)
-%attr(0755,root,root) %caps(cap_sys_admin,cap_sys_chroot=ep) %{_bindir}/bwrap
+%attr(0755,root,root) %caps(cap_sys_admin,cap_net_admin,cap_sys_chroot=ep) %{_bindir}/bwrap
 %else
 %{_bindir}/bwrap
 %endif


### PR DESCRIPTION
It turns out we need CAP_NET_ADMIN in the privileged case in order
to make --unshare-net work because otherwise we're not allowed to
set up the loopback device.