### PR TITLE
[merged] Add --tmpfs argument

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -52,6 +52,7 @@ typedef enum {
   SETUP_DEV_BIND_MOUNT,
   SETUP_MOUNT_PROC,
   SETUP_MOUNT_DEV,
+  SETUP_MOUNT_TMPFS,
   SETUP_MAKE_DIR,
   SETUP_MAKE_FILE,
   SETUP_MAKE_BIND_FILE,
@@ -155,6 +156,7 @@ usage (int ecode)
            "	--file-label LABEL           File label for temporary sandbox content\n"
            "	--proc DEST		     Mount procfs on DEST\n"
            "	--dev DEST		     Mount new dev on DEST\n"
+           "	--tmpfs DEST		     Mount new tmpfs on DEST\n"
            "	--dir DEST		     Create dir at DEST\n"
            "	--file FD DEST		     Copy from FD to dest DEST\n"
            "	--bind-data FD DEST	     Copy from FD to file which is bind-mounted on DEST\n"
@@ -670,6 +672,16 @@ setup_newroot (bool unshare_pid,
 
         break;
 
+      case SETUP_MOUNT_TMPFS:
+        if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          die_with_error ("Can't mkdir %s", op->dest);
+
+        privileged_op (privileged_op_socket,
+                       PRIV_SEP_OP_TMPFS_MOUNT, 0,
+                       dest, NULL);
+
+        break;
+
       case SETUP_MAKE_DIR:
         if (mkdir (dest, 0755) != 0 && errno != EEXIST)
           die_with_error ("Can't mkdir %s", op->dest);
@@ -962,6 +974,17 @@ parse_args (int *argcp,
             die ("--dev takes an argument");
 
           op = setup_op_new (SETUP_MOUNT_DEV);
+          op->dest = argv[1];
+
+          argv += 1;
+          argc -= 1;
+        }
+      else if (strcmp (arg, "--tmpfs") == 0)
+        {
+          if (argc < 2)
+            die ("--tmpfs takes an argument");
+
+          op = setup_op_new (SETUP_MOUNT_TMPFS);
           op->dest = argv[1];
 
           argv += 1;

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -506,7 +506,7 @@ privileged_op (int privileged_op_socket,
     case PRIV_SEP_OP_TMPFS_MOUNT:
       {
         cleanup_free char *opt = label_mount ("mode=0755", opt_file_label);
-        if (mount ("tmpfs", arg1, "tmpfs", MS_MGC_VAL | MS_NOSUID | MS_NOEXEC, opt) != 0)
+        if (mount ("tmpfs", arg1, "tmpfs", MS_MGC_VAL | MS_NOSUID | MS_NODEV, opt) != 0)
           die_with_error ("Can't mount tmpfs on %s", arg1);
         break;
       }

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -179,6 +179,10 @@
       <listitem><para>Mount new devtmpfs on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--tmpfs <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Mount new tmpfs on <arg choice="plain">DEST</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--dir <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Create a directory at <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>


### PR DESCRIPTION
This is very useful if you want to cover some area of the filesystem,
or if you want to make some part of a read-only tree writable.

I'd like to use this for xdg-app to cover up /tmp/.X11-unix in the case where we want access to the host /tmp.