### PR TITLE
[merged] Fix using --dev unprivileged (without --proc)

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -927,7 +927,6 @@ parse_args (int *argcp,
 
           op = setup_op_new (SETUP_MOUNT_PROC);
           op->dest = argv[1];
-          opt_needs_devpts = TRUE;
 
           argv += 1;
           argc -= 1;
@@ -966,6 +965,7 @@ parse_args (int *argcp,
 
           op = setup_op_new (SETUP_MOUNT_DEV);
           op->dest = argv[1];
+          opt_needs_devpts = TRUE;
 
           argv += 1;
           argc -= 1;


### PR DESCRIPTION
If using --dev we need a special workaround to make it possible to
mount devpts. Unfortunately the workaround was erronously enabled
if you added --proc, not --dev. This moves this check to the right
place.

To test, try:
 ./bwrap  --ro-bind / /  --dev /dev true