### PR TITLE
[merged] Propagate exit status when not in a PID namespace

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -274,7 +274,7 @@ monitor_child (int event_fd)
         {
           if (fdsi.ssi_signo != SIGCHLD)
             die ("Read unexpected signal\n");
-          exit (1);
+          exit (fdsi.ssi_status);
         }
     }
 }


### PR DESCRIPTION
If we're not doing a PID namespace, we don't create a monitor
process, which means that the code in `monitor_child()` needs
to properly propagate the exit status from the signalfd.

It might be better to change `monitor_child()` to be a `waitpid()`
loop in this case, but I decided to go for the one liner fix that's an
improvement in both cases anyways.

I noticed this with:

```
bwrap --ro-bind / / --dev /dev true
```

exiting with code 1.