### PR TITLE
[merged] SELinux: Combine label_valid and label_support into one function

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -951,12 +951,9 @@ parse_args (int *argcp,
         {
           if (argc < 2)
             die ("--exec-label takes an argument");
-	  if (label_support () < 0)
-            die ("--exec-label not supported on this system");
-
           opt_exec_label = argv[1];
-          if (label_valid (argv[1]) < 0)
-            die_with_error ("--exec-label invalid");
+          die_unless_label_valid (opt_exec_label);
+
           argv += 1;
           argc -= 1;
         }
@@ -964,10 +961,8 @@ parse_args (int *argcp,
         {
           if (argc < 2)
             die ("--file-label takes an argument");
-	  if (label_support () < 0)
-            die ("--file-label not supported on this system");
-
           opt_file_label = argv[1];
+          die_unless_label_valid (opt_file_label);
           if (label_create_file (opt_file_label))
             die_with_error ("--file-label setup failed");
 

--- a/utils.c
+++ b/utils.c
@@ -55,6 +55,20 @@ die (const char *format, ...)
 }
 
 void
+die_unless_label_valid (const char *label)
+{
+#ifdef HAVE_SELINUX
+  if (is_selinux_enabled () == 1)
+    {
+      if (security_check_context ((security_context_t)label) < 0)
+        die_with_error ("invalid label %s", label);
+      return;
+    }
+#endif
+  die ("labeling not supported on this system");
+}
+
+void
 die_oom (void)
 {
   die ("Out of memory");
@@ -619,16 +633,6 @@ pivot_root (const char * new_root, const char * put_old)
 #endif
 }
 
-int
-label_support ()
-{
-#ifdef HAVE_SELINUX
-  if (is_selinux_enabled () == 1)
-    return 0;
-#endif
-  return -1;
-}
-
 char *
 label_mount (const char *opt, const char *mount_label)
 {
@@ -664,14 +668,4 @@ label_exec (const char *exec_label)
     return setexeccon ((security_context_t)exec_label);
 #endif
   return 0;
-}
-
-int
-label_valid (const char *label)
-{
-#ifdef HAVE_SELINUX
-  if (is_selinux_enabled () > 0 && label)
-    return security_check_context ((security_context_t)label);
-#endif
-  return -1;
 }

--- a/utils.h
+++ b/utils.h
@@ -53,6 +53,8 @@ void  die_with_error (const char  *format,
 void  die            (const char  *format,
                       ...) __attribute__((__noreturn__));
 void  die_oom        (void) __attribute__((__noreturn__));
+void  die_unless_label_valid    (const char *label);
+
 void *xmalloc        (size_t       size);
 void *xcalloc        (size_t       size);
 void *xrealloc       (void        *ptr,
@@ -110,8 +112,6 @@ int   pivot_root     (const char   *new_root,
 char *label_mount    (const char *opt,
 		      const char *mount_label);
 int   label_exec     (const char *exec_label);
-int   label_valid    (const char *label);
-int   label_support  (void);
 int   label_create_file (const char *file_label);
 
 static inline void


### PR DESCRIPTION
All calls to set an SELinux label should call this function

die_unless_label_valid (opt_exec_label);

It will make sure SELinux is enabled and will make sure the user passed in a
valid label.

Signed-off-by: Alexander Larsson <alexl@redhat.com>