### PR TITLE
[merged] Fix fdwalk

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -262,7 +262,7 @@ fdwalk (int proc_fd, int (*cb)(void *data, int fd), void *data)
   int res = 0;
   DIR *d;
 
-  dfd = openat (proc_fd, "self/fd", O_DIRECTORY);
+  dfd = openat (proc_fd, "self/fd", O_DIRECTORY | O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOCTTY);
   if (dfd == -1)
     return res;
 

--- a/utils.c
+++ b/utils.c
@@ -262,7 +262,7 @@ fdwalk (int proc_fd, int (*cb)(void *data, int fd), void *data)
   int res = 0;
   DIR *d;
 
-  dfd = openat (proc_fd, "self/fd", O_DIRECTORY | O_PATH);
+  dfd = openat (proc_fd, "self/fd", O_DIRECTORY);
   if (dfd == -1)
     return res;
 


### PR DESCRIPTION
It turns out you can't readdir from an O_PATH file-descriptor, so
fdwalk didn't work. Spotted the BADFD in a strace.