### PR TITLE
[merged] More robust handler for OOM condition

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -71,7 +71,8 @@ die_unless_label_valid (const char *label)
 void
 die_oom (void)
 {
-  die ("Out of memory");
+  puts ("Out of memory");
+  exit (1);
 }
 
 void *


### PR DESCRIPTION
OOM conditions are a bit special, since `vfprintf` is not standard defined not to allocate any memory it *may happen* and using `puts` should be much safer option. 