### PR TITLE
[merged] send --help to stdout

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -131,11 +131,11 @@ lock_file_new (const char *path)
 
 
 static void
-usage (int ecode)
+usage (int ecode, FILE *out)
 {
-  fprintf (stderr, "usage: %s [OPTIONS...] COMMAND [ARGS...]\n\n", argv0);
+  fprintf (out, "usage: %s [OPTIONS...] COMMAND [ARGS...]\n\n", argv0);
 
-  fprintf (stderr,
+  fprintf (out,
            "    --help                       Print this help\n"
            "    --version                    Print version\n"
            "    --args FD                    Parse nul-separated args from FD\n"
@@ -839,7 +839,7 @@ parse_args_recurse (int *argcp,
       const char *arg = argv[0];
 
       if (strcmp (arg, "--help") == 0)
-        usage (EXIT_SUCCESS);
+        usage (EXIT_SUCCESS, stdout);
       else if (strcmp (arg, "--version") == 0)
         {
           printf ("%s\n", PACKAGE_STRING);
@@ -1247,7 +1247,7 @@ main (int argc,
   argc--;
 
   if (argc == 0)
-    usage (EXIT_FAILURE);
+    usage (EXIT_FAILURE, stderr);
 
   parse_args (&argc, &argv);
 
@@ -1256,7 +1256,7 @@ main (int argc,
     opt_unshare_user = TRUE;
 
   if (argc == 0)
-    usage (EXIT_FAILURE);
+    usage (EXIT_FAILURE, stderr);
 
   __debug__(("Creating root mount point\n"));
 


### PR DESCRIPTION
sending --help output to stderr causing sadness and confusion when
someone tries something obvious like `bwrap --help | less`.  This
commit modifies bubblewrap.c such that `--help` output will go to
stdout, while other  invocations of `usage(...)` will continue to go
to stderr.