### PR TITLE
[merged] Use #pragma once for headers

### DIFF
--- a/bind-mount.h
+++ b/bind-mount.h
@@ -16,8 +16,7 @@
  *
  */
 
-#ifndef __MOUNTS_H__
-#define __MOUNTS_H__
+#pragma once
 
 typedef enum {
   BIND_READONLY = (1 << 0),
@@ -29,5 +28,3 @@ int bind_mount (int           proc_fd,
                 const char   *src,
                 const char   *dest,
                 bind_option_t options);
-
-#endif /* __MOUNTS_H__ */

--- a/network.h
+++ b/network.h
@@ -16,9 +16,6 @@
  *
  */
 
-#ifndef __NETWORK_H__
-#define __NETWORK_H__
+#pragma once
 
 int loopback_setup (void);
-
-#endif /* __NETWORK_H__ */

--- a/utils.h
+++ b/utils.h
@@ -16,8 +16,7 @@
  *
  */
 
-#ifndef __UTILS_H__
-#define __UTILS_H__
+#pragma once
 
 #include <assert.h>
 #include <dirent.h>
@@ -163,5 +162,3 @@ steal_pointer (void *pp)
 /* type safety */
 #define steal_pointer(pp) \
   (0 ? (*(pp)) : (steal_pointer) (pp))
-
-#endif /* __UTILS_H__ */


### PR DESCRIPTION
It's shorter and more reliable.  Also GCC/CLang specific, but that's
fine because that's all we support anyways.

Closes: #69