### PR TITLE
[merged] build: put libraries in LDADD, not LDFLAGS

### DIFF
--- a/Makefile-bwrap.am
+++ b/Makefile-bwrap.am
@@ -10,4 +10,4 @@ bwrap_SOURCES = \
 	$(NULL)
 
 bwrap_CFLAGS = $(AM_CFLAGS)
-bwrap_LDFLAGS = $(SELINUX_LIBS)
+bwrap_LDADD = $(SELINUX_LIBS)


### PR DESCRIPTION
Automake linking looks like this (I'm simplifying a bit):

    $(CC) $(foo_CFLAGS) $(foo_LDFLAGS) -ofoo $(objects) $(foo_LDADD)

The correct order is that if a library A is used to satisfy the symbol
requirements of an object or library B, then A must come after B on the
link line. Otherwise, static linking or linking with -Wl,--as-needed
will fail. As a result, libraries and the -L options used to locate them
should always be in LDADD (for executables) or LIBADD (for libraries),
never in LDFLAGS.

Ubuntu's linker defaults to the equivalent of -Wl,--as-needed, so
this causes failure to build on Ubuntu, which can be reproduced with

    ./autogen.sh CC="gcc -Wl,--as-needed" && make

on other distributions.