### PR TITLE
[merged] Replace canonicalize_file_name with realpath(3)

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1008,7 +1008,7 @@ parse_args_recurse (int    *argcp,
             die ("--bind takes two arguments");
 
           op = setup_op_new (SETUP_BIND_MOUNT);
-          op->source = canonicalize_file_name (argv[1]);
+          op->source = realpath (argv[1], NULL);
           if (op->source == NULL)
             die_with_error ("Can't find source path %s", argv[1]);
           op->dest = argv[2];
@@ -1022,7 +1022,7 @@ parse_args_recurse (int    *argcp,
             die ("--ro-bind takes two arguments");
 
           op = setup_op_new (SETUP_RO_BIND_MOUNT);
-          op->source = canonicalize_file_name (argv[1]);
+          op->source = realpath (argv[1], NULL);
           if (op->source == NULL)
             die_with_error ("Can't find source path %s", argv[1]);
           op->dest = argv[2];
@@ -1036,7 +1036,7 @@ parse_args_recurse (int    *argcp,
             die ("--dev-bind takes two arguments");
 
           op = setup_op_new (SETUP_DEV_BIND_MOUNT);
-          op->source = canonicalize_file_name (argv[1]);
+          op->source = realpath (argv[1], NULL);
           if (op->source == NULL)
             die_with_error ("Can't find source path %s", argv[1]);
           op->dest = argv[2];


### PR DESCRIPTION
canonicalize_file_name is glibc specific. The realpath(3) provide
essentially the same thing but is much more portable. For instance, this
change made it possible to build bubblewrap against musl libc.