### PR TITLE
Add --remount-ro DEST

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -244,8 +244,11 @@ bind_mount (int           proc_fd,
   unsigned long current_flags, new_flags;
   int i;
 
-  if (mount (src, dest, NULL, MS_MGC_VAL | MS_BIND | (recursive ? MS_REC : 0), NULL) != 0)
-    return 1;
+  if (src)
+    {
+      if (mount (src, dest, NULL, MS_MGC_VAL | MS_BIND | (recursive ? MS_REC : 0), NULL) != 0)
+        return 1;
+    }
 
   current_flags = get_mountflags (proc_fd, dest);
 

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -179,6 +179,10 @@
       <listitem><para>Bind mount the host path <arg choice="plain">SRC</arg> readonly on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--remount-ro <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Remount the path <arg choice="plain">DEST</arg> as readonly.  It works only on the specified mount point, without changing any other mount point under the specified path</para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--proc <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Mount procfs on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -33,6 +33,7 @@ _bwrap() {
 		--lock-file
 		--proc
 		--ro-bind
+		--remount-ro
 		--seccomp
 		--setenv
 		--symlink


### PR DESCRIPTION
This allows to remount a mount point as read only.

It will allow us, by remounting / after other mount points are created,
to handle a readonly rootfs as specified in the OCI specs:

https://github.com/opencontainers/runtime-spec/blob/master/config.md#root-configuration

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

```
$ bwrap --bind rootfs / --tmpfs /tmp --remount-ro / touch /tmp/a
$ bwrap --bind rootfs / --tmpfs /tmp --remount-ro / touch /a
touch: cannot touch '/a': Read-only file system
```