### PR TITLE
Add `--block-fd` and `--info-fd` so to be able to manage OCI hooks.

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1700,7 +1700,7 @@ main (int    argc,
         die_with_error ("Can't read seccomp data");
 
       if (seccomp_len % 8 != 0)
-        die ("Invalide seccomp data, must be multiple of 8");
+        die ("Invalid seccomp data, must be multiple of 8");
 
       prog.len = seccomp_len / 8;
       prog.filter = (struct sock_filter *) seccomp_data;

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -235,6 +235,12 @@
 	the SELinux context for the sandbox content.
       </para></listitem>
     </varlistentry>
+    <varlistentry>
+      <term><option>--block-fd <arg choice="plain">FD</arg></option></term>
+      <listitem><para>
+	Block the sandbox on reading from FD until some data is available.
+      </para></listitem>
+    </varlistentry>
   </variablelist>
 </refsect1>
 

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -241,6 +241,12 @@
 	Block the sandbox on reading from FD until some data is available.
       </para></listitem>
     </varlistentry>
+    <varlistentry>
+      <term><option>--info-fd <arg choice="plain">FD</arg></option></term>
+      <listitem><para>
+	Write information in JSON format about the sandbox to FD.
+      </para></listitem>
+    </varlistentry>
   </variablelist>
 </refsect1>
 


### PR DESCRIPTION
--block-fd is used to block execution of the child process, while --info-fd returns the pid of the container process (can be extended to export more information, if needed).
