### PR TITLE
[merged] Ro bind data

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -820,6 +820,11 @@ setup_newroot (bool unshare_pid,
                            PRIV_SEP_OP_BIND_MOUNT,
                            (op->type == SETUP_MAKE_RO_BIND_FILE ? BIND_READONLY : 0),
                            tempfile, dest);
+
+            /* Remove the file so we're sure the app can't get to it in any other way.
+               Its outside the container chroot, so it shouldn't be possible, but lets
+               make it really sure. */
+            unlink (tempfile);
           }
           break;
 

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -219,6 +219,10 @@
       <listitem><para>Copy from the file descriptor <arg choice="plain">FD</arg> to a file which is bind-mounted on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--ro-bind-data <arg choice="plain">FD</arg> <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Copy from the file descriptor <arg choice="plain">FD</arg> to a file which is bind-mounted readonly on <arg choice="plain">DEST</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--symlink <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Create a symlink at <arg choice="plain">DEST</arg> with target <arg choice="plain">SRC</arg></para></listitem>
     </varlistentry>


### PR DESCRIPTION
This adds --ro-bind-data, which is similar to --bind-data, but mounts it readonly.

I want to use this in flatpak to put an unmodifiable file in the user sandbox with information about it. Then this can be read back in both the app, and outside it, via `/proc/$pid/root/`.