### PR TITLE
[merged] Protect against hostname changes with unshared UTS namespace

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -51,6 +51,24 @@ static int proc_fd = -1;
 static char *opt_exec_label = NULL;
 static char *opt_file_label = NULL;
 
+char *opt_chdir_path = NULL;
+bool opt_unshare_user = FALSE;
+bool opt_unshare_user_try = FALSE;
+bool opt_unshare_pid = FALSE;
+bool opt_unshare_ipc = FALSE;
+bool opt_unshare_net = FALSE;
+bool opt_unshare_uts = FALSE;
+bool opt_unshare_cgroup = FALSE;
+bool opt_unshare_cgroup_try = FALSE;
+bool opt_needs_devpts = FALSE;
+uid_t opt_sandbox_uid = -1;
+gid_t opt_sandbox_gid = -1;
+int opt_sync_fd = -1;
+int opt_block_fd = -1;
+int opt_info_fd = -1;
+int opt_seccomp_fd = -1;
+char *opt_sandbox_hostname = NULL;
+
 typedef enum {
   SETUP_BIND_MOUNT,
   SETUP_RO_BIND_MOUNT,
@@ -891,25 +909,6 @@ read_priv_sec_op (int          read_socket,
 
   return op->op;
 }
-
-char *opt_chdir_path = NULL;
-bool opt_unshare_user = FALSE;
-bool opt_unshare_user_try = FALSE;
-bool opt_unshare_pid = FALSE;
-bool opt_unshare_ipc = FALSE;
-bool opt_unshare_net = FALSE;
-bool opt_unshare_uts = FALSE;
-bool opt_unshare_cgroup = FALSE;
-bool opt_unshare_cgroup_try = FALSE;
-bool opt_needs_devpts = FALSE;
-uid_t opt_sandbox_uid = -1;
-gid_t opt_sandbox_gid = -1;
-int opt_sync_fd = -1;
-int opt_block_fd = -1;
-int opt_info_fd = -1;
-int opt_seccomp_fd = -1;
-char *opt_sandbox_hostname = NULL;
-
 
 static void
 parse_args_recurse (int    *argcp,

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -612,6 +612,10 @@ privileged_op (int         privileged_op_socket,
       break;
 
     case PRIV_SEP_OP_SET_HOSTNAME:
+      /* This is checked at the start, but lets verify it here in case
+         something manages to send hacked priv-sep operation requests. */
+      if (!opt_unshare_uts)
+        die ("Refusing to set hostname in original namespace");
       if (sethostname (arg1, strlen(arg1)) != 0)
         die_with_error ("Can't set hostname to %s", arg1);
       break;


### PR DESCRIPTION
As reported in https://github.com/projectatomic/bubblewrap/issues/107 we're currently vulnerable to ptrace of the unprivileged part of the child setup. This allows the hostname to be set, even for the host in case the UTS namespace is not unshared.

This is a quick fix to disallow this. We also want to look into the DUMPABLE handling a bit more carefully.