### PR TITLE
[merged] Work around user-namespaces allowing ptrace

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,9 +18,19 @@ if PRIV_MODE_FILECAPS
 endif
 endif
 
+check_PROGRAMS = test-bwrap
+
+test-bwrap: bwrap
+	rm -rf test-bwrap
+	cp bwrap test-bwrap
+if PRIV_MODE_SETUID
+	$(SUDO_BIN) chown root test-bwrap
+	$(SUDO_BIN) chmod u+s test-bwrap
+endif
+
 include Makefile-docs.am
 
-TESTS = tests/test-basic.sh
+TESTS = tests/test-basic.sh tests/test-run.sh
 TESTS_ENVIRONMENT = PATH=$$(cd $(top_builddir) && pwd):$${PATH}
 
 if ENABLE_BASH_COMPLETION

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,10 +12,6 @@ install-exec-hook:
 if PRIV_MODE_SETUID
 	$(SUDO_BIN) chown root $(DESTDIR)$(bindir)/bwrap
 	$(SUDO_BIN) chmod u+s $(DESTDIR)$(bindir)/bwrap
-else
-if PRIV_MODE_FILECAPS
-	$(SUDO_BIN) setcap cap_sys_admin,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep $(DESTDIR)$(bindir)/bwrap
-endif
 endif
 
 check_PROGRAMS = test-bwrap

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -44,7 +44,7 @@
 /* Globals to avoid having to use getuid(), since the uid/gid changes during runtime */
 static uid_t uid;
 static gid_t gid;
-static bool is_privileged;
+static bool is_privileged; /* true if we're either setuid root, or really running as root */
 static const char *argv0;
 static const char *host_tty_dev;
 static int proc_fd = -1;
@@ -403,13 +403,7 @@ acquire_caps (void)
   struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
   struct __user_cap_data_struct data[2] = { { 0 } };
 
-  if (capget (&hdr, data)  < 0)
-    die_with_error ("capget failed");
-
-  if (((data[0].effective & REQUIRED_CAPS_0) == REQUIRED_CAPS_0) &&
-      ((data[0].permitted & REQUIRED_CAPS_0) == REQUIRED_CAPS_0) &&
-      ((data[1].effective & REQUIRED_CAPS_1) == REQUIRED_CAPS_1) &&
-      ((data[1].permitted & REQUIRED_CAPS_1) == REQUIRED_CAPS_1))
+  if (geteuid () == 0)
     is_privileged = TRUE;
 
   if (getuid () != geteuid ())

--- a/configure.ac
+++ b/configure.ac
@@ -74,12 +74,11 @@ changequote([,])dnl
 AC_SUBST(WARN_CFLAGS)
 
 AC_ARG_WITH(priv-mode,
-            AS_HELP_STRING([--with-priv-mode=setuid/caps/none],
+            AS_HELP_STRING([--with-priv-mode=setuid/none],
                            [How to set privilege-raising during make install)]),
             [],
             [with_priv_mode="none"])
 
-AM_CONDITIONAL(PRIV_MODE_FILECAPS, test "x$with_priv_mode" = "xcaps")
 AM_CONDITIONAL(PRIV_MODE_SETUID, test "x$with_priv_mode" = "xsetuid")
 
 AC_ARG_ENABLE(sudo,

--- a/packaging/bubblewrap.spec
+++ b/packaging/bubblewrap.spec
@@ -41,7 +41,7 @@ find $RPM_BUILD_ROOT -name '*.la' -delete
 %doc README.md
 %{_datadir}/bash-completion/completions/bwrap
 %if (0%{?rhel} != 0 && 0%{?rhel} <= 7)
-%attr(0755,root,root) %caps(cap_sys_admin,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid=ep) %{_bindir}/bwrap
+%attr(4755,root,root) %{_bindir}/bwrap
 %else
 %{_bindir}/bwrap
 %endif

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -30,6 +30,6 @@ assert_file_has_content () {
 # At the moment we're testing in Travis' container infrastructure
 # which also uses PR_SET_NO_NEW_PRIVS...but let's at least
 # verify --help works!
-bwrap --help >out.txt 2>&1
+test-bwrap --help >out.txt 2>&1
 assert_file_has_content out.txt "--lock-file"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -xeuo pipefail
+
+srcd=$(cd $(dirname $0) && pwd)
+bn=$(basename $0)
+tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
+touch ${tempdir}/.testtmp
+function cleanup () {
+    if test -n "${TEST_SKIP_CLEANUP:-}"; then
+        echo "Skipping cleanup of ${test_tmpdir}"
+    else if test -f ${tempdir}/.test; then
+        rm "${tempdir}" -rf
+    fi
+    fi
+}
+trap cleanup EXIT
+cd ${tempdir}
+
+skip () {
+    echo $@ 1>&2; exit 77
+}
+
+assert_not_reached () {
+    echo $@ 1>&2; exit 1
+}
+
+assert_file_has_content () {
+    if ! grep -q -e "$2" "$1"; then
+        echo 1>&2 "File '$1' doesn't match regexp '$2'"; exit 1
+    fi
+}
+
+FUSE_DIR=
+for mp in `cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=1000 | awk '{print $2}'`; do
+    if test -d $mp; then
+        echo Using $mp as test fuse mount
+        FUSE_DIR=$mp
+        break
+    fi
+done
+
+# This is supposed to be an otherwise readable file in an unreadable (by the user) dir
+UNREADABLE=/root/.bashrc
+if test -x `dirname $UNREADABLE`; then
+    UNREADABLE=
+fi
+
+# Default arg, bind whole host fs to /, tmpfs on /tmp
+BWRAP="test-bwrap --bind / / --tmpfs /tmp"
+
+if ! $BWRAP true; then
+    skip Seems like bwrap is not working at all. Maybe setuid is not working
+fi
+
+#TODO: More ALTs when remount fixed:  "--unshare-pid" "--unshare-user --unshare-pid"
+for ALT in "" "--unshare-user" ; do
+    # Test fuse fs as bind source
+    if [ x$FUSE_DIR != x ]; then
+        $BWRAP $ALT  --proc /proc --dev /dev --bind $FUSE_DIR /tmp/foo true
+    fi
+    # no --dev => no devpts => no map_root workaround
+    $BWRAP $ALT --proc /proc true
+    # No network
+    $BWRAP $ALT --unshare-net --proc /proc --dev /dev true
+    # Unreadable file
+    echo -n "expect EPERM: "
+    if $BWRAP $ALT --unshare-net --proc /proc --bind /etc/shadow  /tmp/foo cat /etc/shadow; then
+        assert_not_reached Could read /etc/shadow
+    fi
+    # Unreadable dir
+    if [ x$UNREADABLE != x ]; then
+        echo -n "expect EPERM: "
+        if $BWRAP $ALT --unshare-net --proc /proc --dev /dev --bind $UNREADABLE  /tmp/foo cat /tmp/foo ; then
+            assert_not_reached Could read $UNREADABLE
+        fi
+    fi
+done
+echo OK


### PR DESCRIPTION
This is a new approach to https://github.com/projectatomic/bubblewrap/pull/114

The linux kernel grants any process in the parent user namespace
that matches the uid of namespace owner full capabilities in the
child namespace. This includes CAP_PTRACE, which overrides the
limit that you can't ptrace non-dumpable processes.
    
This is a problem for the bubblewrap setup code in case you use
--unshare-user, as you can then ptrace the setup code directly after
the clone() call, and gain full capabilities in the child user
namespace.
    
This is not necessarily a huge problem, as the kernel shouldn't allow
you to do anything you couldn't outside the user namespace. However,
not everyone trusts the user namespace implementation, and one of the
points of bubblewrap is to be able to securely allow a small subset of
user namespaces, and this was voided by this ptrace ability.
    
The workaround we use is to run the initial part (up to the clone call)
of the setup as euid 0 rather than the real uid. This causes the
user namespace to be owned by root, and the user cannot ptrace it.
    
To protect against incorrect permission checks during this initial
part of the setup, we use setfsuid to make the fs checks use the real
uid.  Additionally, the previous workaround for uid_map permission
issues (https://github.com/projectatomic/bubblewrap/pull/110) has been
replaced with one that uses setfsuid instead
(based on https://github.com/projectatomic/bubblewrap/pull/109).
    
Once we're in the namespace we switch to the real user so that setup
can get the real uid, which is needed to e.g. allow fuse access.
