### PR TITLE
[merged] bind-mount: Fix issue when destination of mount is in a symlink

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -74,5 +74,8 @@ for ALT in "" "--unshare-user"  "--unshare-pid" "--unshare-user --unshare-pid"; 
             assert_not_reached Could read $UNREADABLE
         fi
     fi
+
+    # bind dest in symlink (https://github.com/projectatomic/bubblewrap/pull/119)
+    $BWRAP $ALT --dir /tmp/dir --symlink dir /tmp/link --bind /etc /tmp/link true
 done
 echo OK


### PR DESCRIPTION
There is a regression from https://github.com/projectatomic/bubblewrap/pull/118, it turns out @cgwalters was right and there *was* a canonicalization issue:

The mount operation always fully resolves any symlinks before mounting
so we need to do the same when we're looking for the new mount
in the mount tables.

Without this something like
 --symlink /dst /link --bind-mount /src /link
 would fail because it would look for mount flags in /link, but the
 mount would be on /dst.