### PR TITLE
[merged] Fix incorrect nesting of backticks when finding a FUSE mount

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -32,7 +32,7 @@ assert_file_has_content () {
 }
 
 FUSE_DIR=
-for mp in `cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=`id -u` | awk '{print $2}'`; do
+for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=$(id -u) | awk '{print $2}'); do
     if test -d $mp; then
         echo Using $mp as test fuse mount
         FUSE_DIR=$mp


### PR DESCRIPTION
---

Unfortunately this is in a context where failed command evaluation goes unnoticed, and I spotted the syntax error just as the bot merged my branch. :-(