### PR TITLE
[merged] Don't call capset() unless we need to

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -459,12 +459,13 @@ acquire_privs (void)
   uid_t euid, new_fsuid;
 
   euid = geteuid ();
-  if (euid == 0)
-    is_privileged = TRUE;
 
+  /* Are we setuid ? */
   if (real_uid != euid)
     {
-      if (euid != 0)
+      if (euid == 0)
+        is_privileged = TRUE;
+      else
         die ("Unexpected setuid user %d, should be 0", euid);
 
       /* We want to keep running as euid=0 until at the clone()


### PR DESCRIPTION
Fedora runs rpm-ostree (which uses bwrap) in systemd-nspawn (in mock via
`--new-chroot`).  nspawn by default installs a seccomp policy that
denies `capset()`.

This started failing with bubblewrap-0.1.4:
https://pagure.io/releng/issue/6550

The process currently runs as *real* uid 0, outside of a user namespace.
(It's honestly a bit nonsensical for nspawn to give a process `CAP_SYS_ADMIN`
 outside of a userns, but use seccomp to deny `capset()`, but let's leave
 that aside for now.)

Due to the way this code was structured, we set `is_privileged = TRUE`
simply because we have uid 0, even in the Fedora case where we *aren't*
privileged.

Fix this so we only set is_privileged if `uid != euid`, hence we
won't try to gain/drop any capabilities, which fixes compatibility
with what nspawn is doing.

In theory of course we *could* drop privileges in a userns scenario,
but we'd only be dropping privs in our userns...eh.