### PR TITLE
[merged] Only --unshare-user automatically if we're not root

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1631,8 +1631,10 @@ main (int    argc,
 
   parse_args (&argc, &argv);
 
-  /* We have to do this if we weren't installed setuid, so let's just DWIM */
-  if (!is_privileged)
+  /* We have to do this if we weren't installed setuid (and we're not
+   * root), so let's just DWIM
+*/
+  if (!is_privileged && getuid () != 0)
     opt_unshare_user = TRUE;
 
   if (opt_unshare_user_try &&

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1632,8 +1632,7 @@ main (int    argc,
   parse_args (&argc, &argv);
 
   /* We have to do this if we weren't installed setuid (and we're not
-   * root), so let's just DWIM
-*/
+   * root), so let's just DWIM */
   if (!is_privileged && getuid () != 0)
     opt_unshare_user = TRUE;
 


### PR DESCRIPTION
https://github.com/projectatomic/bubblewrap/pull/122 introduced a
regression for the case of rpm-ostree running bubblewrap on CentOS 7.

Previously the `is_privileged` variable captured whether or not
our uid was 0, now it captures whether we're setuid.

This bit of code enabled `--unshare-user` automatically if we're not
privileged, but we suddenly started doing that for running as real uid
0 (CAP_SYS_ADMIN), which we don't want, since on CentOS/RHEL 7 today
userns isn't even available to root without a module parameter and
reboot.

So, let's just do this only if not setuid *and* we're not uid 0
(really we should check "have CAP_SYS_ADMIN" but eh).