### PR TITLE
[merged] demo/shell: Add /var/tmp compat symlink, tweak PS1, add more docs

### DIFF
--- a/demos/bubblewrap-shell.sh
+++ b/demos/bubblewrap-shell.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
-# Use bubblewrap to run /bin/sh in the host's rootfs.
+# Use bubblewrap to run /bin/sh reusing the host OS binaries (/usr), but with
+# separate /tmp, /var, /run, and /etc. For /etc we just inherit the host's
+# resolv.conf, and set up "stub" passwd/group files.
+#
+# You can build on this example; for example, use --unshare-net to disable
+# networking.
 set -euo pipefail
 (exec bwrap --ro-bind /usr /usr \
       --dir /tmp \
+      --dir /var \
+      --symlink ../tmp var/tmp \
       --proc /proc \
       --dev /dev \
       --ro-bind /etc/resolv.conf /etc/resolv.conf \
@@ -14,6 +21,7 @@ set -euo pipefail
       --unshare-pid \
       --dir /run/user/$(id -u) \
       --setenv XDG_RUNTIME_DIR "/run/user/`id -u`" \
+      --setenv PS1 "bwrap-demo$ " \
       --file 11 /etc/passwd \
       --file 12 /etc/group \
       /bin/sh) \


### PR DESCRIPTION
I was working on rpm-ostree's use of bwrap and realized we weren't setting up
/var/tmp. I think this should be a best practice for app compatibility.

I also took the opportunity to expand the docs a bit, and overriding PS1 helps
users know they're in the container shell.