### PR TITLE
[merged] Call setsid() before executing sandboxed code (CVE-2017-5226)

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2071,6 +2071,9 @@ main (int    argc,
   /* We want sigchild in the child */
   unblock_sigchild ();
 
+  if (setsid () == (pid_t) -1)
+    die_with_error ("setsid");
+
   if (label_exec (opt_exec_label) == -1)
     die_with_error ("label_exec %s", argv[0]);
 


### PR DESCRIPTION
This prevents the sandboxed code from getting a controlling tty,
which in turn prevents it from accessing the TIOCSTI ioctl and hence
faking terminal input.

Fixes: #142 

---

Note that this breaks shell job control:

```
user@host:~% ~/src/bubblewrap/bwrap --ro-bind / / --chdir / --dev /dev bash
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
user@host:~$ 
```

I think that's an acceptable sacrifice, but if you disagree, the other mechanism seen in setuid things seems to be non-trivial use of seccomp: https://github.com/karelzak/util-linux/commit/8e4925016875c6a4f2ab4f833ba66f0fc57396a2