### PR TITLE
enable user namespaces by default when used with suid

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1636,6 +1636,10 @@ main (int    argc,
   if (!is_privileged && getuid () != 0)
     opt_unshare_user = TRUE;
 
+  /* user namespaces should also be used if installed suid for security reasons */
+  if (is_privileged && getuid () != 0)
+    opt_unshare_user_try = TRUE;
+  
   if (opt_unshare_user_try &&
       stat ("/proc/self/ns/user", &sbuf) == 0)
     {


### PR DESCRIPTION
When running with suid on a system that supports user namespaces for privileged users only, user namespaces should still be used by default (using --unshare-user-try)

I believe that running namespaces outside a user namespace is insecure as namespaces (except for user namespaces) were not designed to be run by unprivileged users.
Using PR_SET_NO_NEW_PRIVS and mounting with nosuid will prevent easy exploits but there might still be ways to exploit this. When (privileged) user namespaces are available, using it by default will close this potential risk, without any known drawback. 

As for Systems without any support for user namespaces, bwrap will still work (without a user namespace)

Also see #141 