### PR TITLE
[merged] Add --unshare-all and --share-net

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -180,6 +180,8 @@ usage (int ecode, FILE *out)
            "    --help                       Print this help\n"
            "    --version                    Print version\n"
            "    --args FD                    Parse nul-separated args from FD\n"
+           "    --unshare-all                Unshare every namespace we support by default\n"
+           "    --share-net                  Retain the network namespace (can only combine with --unshare-all)\n"
            "    --unshare-user               Create new user namespace (may be automatically implied if not setuid)\n"
            "    --unshare-user-try           Create new user namespace if possible else continue by skipping it\n"
            "    --unshare-ipc                Create new ipc namespace\n"
@@ -1214,6 +1216,17 @@ parse_args_recurse (int    *argcp,
           argv += 1;
           argc -= 1;
         }
+      else if (strcmp (arg, "--unshare-all") == 0)
+        {
+          /* Keep this in order with the older (legacy) --unshare arguments,
+           * we use the --try variants of user and cgroup, since we want
+           * to support systems/kernels without support for those.
+           */
+          opt_unshare_user_try = opt_unshare_ipc = opt_unshare_pid =
+            opt_unshare_uts = opt_unshare_cgroup_try =
+            opt_unshare_net = TRUE;
+        }
+      /* Begin here the older individual --unshare variants */
       else if (strcmp (arg, "--unshare-user") == 0)
         {
           opt_unshare_user = TRUE;
@@ -1246,6 +1259,12 @@ parse_args_recurse (int    *argcp,
         {
           opt_unshare_cgroup_try = TRUE;
         }
+      /* Begin here the newer --share variants */
+      else if (strcmp (arg, "--share-net") == 0)
+        {
+          opt_unshare_net = FALSE;
+        }
+      /* End --share variants, other arguments begin */
       else if (strcmp (arg, "--chdir") == 0)
         {
           if (argc < 2)

--- a/demos/bubblewrap-shell.sh
+++ b/demos/bubblewrap-shell.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Use bubblewrap to run /bin/sh reusing the host OS binaries (/usr), but with
-# separate /tmp, /var, /run, and /etc. For /etc we just inherit the host's
-# resolv.conf, and set up "stub" passwd/group files.
+# separate /tmp, /home, /var, /run, and /etc. For /etc we just inherit the
+# host's resolv.conf, and set up "stub" passwd/group files.  Not sharing
+# /home for example is intentional.  If you wanted to, you could design
+# a bwrap-using program that shared individual parts of /home, perhaps
+# public content.
 #
-# You can build on this example; for example, use --unshare-net to disable
+# Another way to build on this example is to remove --share-net to disable
 # networking.
 set -euo pipefail
 (exec bwrap --ro-bind /usr /usr \
@@ -18,12 +21,8 @@ set -euo pipefail
       --symlink usr/bin /bin \
       --symlink usr/sbin /sbin \
       --chdir / \
-      --unshare-pid \
-      --unshare-user-try \
-      --unshare-ipc \
-      --unshare-net \
-      --unshare-uts \
-      --unshare-cgroup-try \
+      --unshare-all \
+      --share-net \
       --dir /run/user/$(id -u) \
       --setenv XDG_RUNTIME_DIR "/run/user/`id -u`" \
       --setenv PS1 "bwrap-demo$ " \


### PR DESCRIPTION
In discussion in https://github.com/projectatomic/bubblewrap/pull/150
it was noted that most of the bwrap command line tends towards "closed
by default, request open".  But the `--unshare` options are inverse.

Now, I suspect in practice there's only one namespace that most users
will care about, which is the network namespace.  There are very useful
programs to build on both cases.

I think everything else (pid, ipc, uts) people will want as a group.
Any cases that are unusual enough to want to turn one of them off
can still fall back to the previous bwrap behavior of explicitly
unsharing.  They're likely to be security sensitive enough
that if a new namespace were added, it would make sense to evaluate
the tool.

But again I think most users will want all namespaces, with the network one as a
primary "enable it" option.