### PR TITLE
[merged] Make the call to setsid() optional, with --new-session

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -64,6 +64,7 @@ bool opt_unshare_uts = FALSE;
 bool opt_unshare_cgroup = FALSE;
 bool opt_unshare_cgroup_try = FALSE;
 bool opt_needs_devpts = FALSE;
+bool opt_new_session = FALSE;
 uid_t opt_sandbox_uid = -1;
 gid_t opt_sandbox_gid = -1;
 int opt_sync_fd = -1;
@@ -213,6 +214,7 @@ usage (int ecode, FILE *out)
            "    --seccomp FD                 Load and use seccomp rules from FD\n"
            "    --block-fd FD                Block on FD until some data to read is available\n"
            "    --info-fd FD                 Write information about the running container to FD\n"
+           "    --new-session                Create a new terminal session\n"
           );
   exit (ecode);
 }
@@ -1586,6 +1588,10 @@ parse_args_recurse (int    *argcp,
           argv += 1;
           argc -= 1;
         }
+      else if (strcmp (arg, "--new-session") == 0)
+        {
+          opt_new_session = TRUE;
+        }
       else if (*arg == '-')
         {
           die ("Unknown option %s", arg);
@@ -2121,7 +2127,8 @@ main (int    argc,
   /* We want sigchild in the child */
   unblock_sigchild ();
 
-  if (setsid () == (pid_t) -1)
+  if (opt_new_session &&
+      setsid () == (pid_t) -1)
     die_with_error ("setsid");
 
   if (label_exec (opt_exec_label) == -1)

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -264,6 +264,18 @@
 	Write information in JSON format about the sandbox to FD.
       </para></listitem>
     </varlistentry>
+    <varlistentry>
+      <term><option>--new-session</option></term>
+      <listitem><para>
+	Create a new terminal session for the sandbox (calls setsid()). This
+        disconnects the sandbox from the controlling terminal which means
+        the sandbox can't for instance inject input into the terminal.
+        </para><para>
+        Note: In a general sandbox, if you don't use --new-session, it is
+        recommended to use seccomp to disallow the TIOCSTI ioctl, otherwise
+        the application can feed keyboard input to the terminal.
+      </para></listitem>
+    </varlistentry>
   </variablelist>
 </refsect1>
 

--- a/demos/bubblewrap-shell.sh
+++ b/demos/bubblewrap-shell.sh
@@ -19,6 +19,11 @@ set -euo pipefail
       --symlink usr/sbin /sbin \
       --chdir / \
       --unshare-pid \
+      --unshare-user-try \
+      --unshare-ipc \
+      --unshare-net \
+      --unshare-uts \
+      --unshare-cgroup-try \
       --dir /run/user/$(id -u) \
       --setenv XDG_RUNTIME_DIR "/run/user/`id -u`" \
       --setenv PS1 "bwrap-demo$ " \


### PR DESCRIPTION
This means we stay compatible with apps using the old bwrap, yet still makes it easy to avoid CVE-2017-5226 in apps using bwrap.
    
Also, recommend that applications not using --new-session should use a seccomp filter for the TIOCSTI ioctl to avoid the input injection issue.

Also, tighten up the demo shell a bit.

This is an alternative to https://github.com/projectatomic/bubblewrap/pull/150