### PR TITLE
[merged] Added compile flag to enable user namespace by default when installed suid

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1718,6 +1718,12 @@ main (int    argc,
   if (!is_privileged && getuid () != 0)
     opt_unshare_user = TRUE;
 
+#ifdef ENABLE_REQUIRE_USERNS
+  /* In this build option, we require userns. */
+  if (is_privileged && getuid () != 0)
+    opt_unshare_user = TRUE;
+#endif
+
   if (opt_unshare_user_try &&
       stat ("/proc/self/ns/user", &sbuf) == 0)
     {

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,16 @@ AC_ARG_ENABLE(sudo,
               [SUDO_BIN="sudo"], [SUDO_BIN=""])
 AC_SUBST([SUDO_BIN])
 
+AC_ARG_ENABLE(require-userns,
+            AS_HELP_STRING([--enable-require-userns=yes/no (default no)],
+                           [Require user namespaces by default when installed suid]),
+            [],
+            [enable_require_userns="no"])
+
+AS_IF([ test "x$enable_require_userns" = "xyes" ], [
+        AC_DEFINE(ENABLE_REQUIRE_USERNS, 1, [Define if userns should be used by default in suid mode])
+     ])
+
 AC_CONFIG_FILES([
 Makefile
 ])
@@ -112,5 +122,6 @@ echo "
     man pages (xsltproc):                         $enable_man
     SELinux:                                      $have_selinux
     setuid mode on make install:                  $with_priv_mode
+    require default userns:                       $enable_require_userns
     mysteriously satisfying to pop:               yes"
 echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AC_SUBST(WARN_CFLAGS)
 
 AC_ARG_WITH(priv-mode,
             AS_HELP_STRING([--with-priv-mode=setuid/none],
-                           [How to set privilege-raising during make install)]),
+                           [How to set privilege-raising during make install]),
             [],
             [with_priv_mode="none"])
 


### PR DESCRIPTION
To ensure the same behavior when installed suid as with unprivileged user namespaces available, compile with '--with-default-userns=yes'

This will enable user namespaces by default when installed with suid.