### PR TITLE
ci: Revamp to actually run the tests

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,4 +1,5 @@
 context: centos7
+required: true
 
 branches:
     - master
@@ -18,6 +19,7 @@ timeout: 30m
 inherit: true
 
 context: f25-asan-ubsan
+required: true
 
 tests:
   - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address' ./ci/redhat-ci.sh fedora:25

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,62 +1,17 @@
+context: centos7
+
 branches:
     - master
     - auto
     - try
 
-container:
-    image: centos:7
+host:
+    distro: centos/7/atomic
 
-packages:
-  # Core things to pull from the rpm spec when rhci does that
-  - autoconf
-  - automake
-  - libtool
-  - make
-  - gcc
-  - redhat-rpm-config
-  - libcap-devel
-  - pkgconfig(libselinux)
-  - libxslt
-  - docbook-style-xsl
-
-build:
-  config-opts: >
-    --prefix=/usr
-    --libdir=/usr/lib64
+tests:
+  - env BWRAP_SUID=true ./ci/redhat-ci.sh centos:7
 
 timeout: 30m
-
-artifacts:
-    - test-suite.log
-
----
-
-inherit: true
-
-context: clang-f25
-
-container:
-    image: fedora:25
-
-packages:
-  # Copy and paste of above since we can't inherit right now
-  - autoconf
-  - automake
-  - libtool
-  - make
-  - gcc
-  - redhat-rpm-config
-  - libcap-devel
-  - pkgconfig(libselinux)
-  - libxslt
-  - docbook-style-xsl
-  - clang
-  - libubsan
-  - libasan
-
-env:
-    CC: 'clang'
-    CFLAGS: '-Werror=unused-variable'
 
 ---
 
@@ -64,6 +19,5 @@ inherit: true
 
 context: f25-asan-ubsan
 
-env:
-    CC: 'gcc'
-    CFLAGS: '-g -Og -fsanitize=undefined -fsanitize=address'
+tests:
+  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address' ./ci/redhat-ci.sh fedora:25

--- a/ci/redhat-ci.sh
+++ b/ci/redhat-ci.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+distro=$1
+
+runcontainer() {
+    docker run --rm --env=container=true --env=BWRAP_SUID=${BWRAP_SUID:-} --env CFLAGS="${CFLAGS:-}" --net=host --privileged -v /usr:/host/usr -v $(pwd):/srv/code -w /srv/code $distro ./ci/redhat-ci.sh $distro
+}
+
+buildinstall_to_host() {
+
+    yum -y install git autoconf automake libtool make gcc redhat-rpm-config \
+        libcap-devel  'pkgconfig(libselinux)' 'libxslt' 'docbook-style-xsl' \
+        lib{a,ub,t}san /usr/bin/eu-readelf
+
+    echo testing: $(git describe --tags --always --abbrev=42)
+
+    env NOCONFIGURE=1 ./autogen.sh
+    ./configure --prefix=/usr --libdir=/usr/lib64
+    make -j 8
+    tmpd=$(mktemp -d)
+    make install DESTDIR=${tmpd}
+    for san in a t ub; do
+        if eu-readelf -d ${tmpd}/usr/bin/bwrap | grep -q "NEEDED.*lib${san}san"; then
+            for x in /usr/lib64/lib${san}san*.so.*; do
+                install -D $x ${tmpd}${x}
+            done
+        fi
+    done
+    rsync -rlv ${tmpd}/usr/ /host/usr/
+    if ${BWRAP_SUID}; then
+        chmod u+s /host/usr/bin/bwrap
+    fi
+    rm ${tmpd} -rf
+}
+
+if test -z "${container:-}"; then
+    ostree admin unlock
+    # Hack until the host tree is updated in rhci
+    rpm -Uvh https://kojipkgs.fedoraproject.org//packages/glibc/2.24/4.fc25/x86_64/{libcrypt-nss,glibc,glibc-common,glibc-all-langpacks}-2.24-4.fc25.x86_64.rpm
+    useradd bwrap-tester
+    runcontainer
+    runuser -u bwrap-tester ./tests/test-run.sh
+else
+    buildinstall_to_host
+fi

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -53,7 +53,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-for ALT in "" "--unshare-user"  "--unshare-pid" "--unshare-user --unshare-pid"; do
+for ALT in "" "--unshare-user-try"  "--unshare-pid" "--unshare-user-try --unshare-pid"; do
     # Test fuse fs as bind source
     if [ x$FUSE_DIR != x ]; then
         $RUN $ALT  --proc /proc --dev /dev --bind $FUSE_DIR /tmp/foo true


### PR DESCRIPTION
Previously we were just building in a container, now we actually run the test
script.

This explicitly does builds in a container still, and only installs
the bwrap binaries into the host's `/usr`.  Down the line I think
we can enable better support for this model in redhat-ci.