### PR TITLE
network: Also set errno in cases where netlink gives us an error

### DIFF
--- a/network.c
+++ b/network.c
@@ -78,15 +78,22 @@ rtnl_read_reply (int rtnl_fd,
       while (received >= NLMSG_HDRLEN)
         {
           if (rheader->nlmsg_seq != seq_nr)
-            return -1;
+            {
+              errno = EINVAL;
+              return -1;
+            }
           if (rheader->nlmsg_pid != getpid ())
-            return -1;
+            {
+              errno = EINVAL;
+              return -1;
+            }
           if (rheader->nlmsg_type == NLMSG_ERROR)
             {
               uint32_t *err = NLMSG_DATA (rheader);
               if (*err == 0)
                 return 0;
 
+              errno = -*err;
               return -1;
             }
           if (rheader->nlmsg_type == NLMSG_DONE)


### PR DESCRIPTION
I did test this and it works...but I'm a little uncertain about whether it's
correct. Netlink scares me :smile: I tried looking at other reference code, but
systemd has custom bindings, and NetworkManager uses a different netlink
library.