### PR TITLE
ci: Disable ASAN leak checking

### DIFF
--- a/ci/redhat-ci.sh
+++ b/ci/redhat-ci.sh
@@ -41,7 +41,7 @@ if test -z "${container:-}"; then
     rpm -Uvh https://kojipkgs.fedoraproject.org//packages/glibc/2.24/4.fc25/x86_64/{libcrypt-nss,glibc,glibc-common,glibc-all-langpacks}-2.24-4.fc25.x86_64.rpm
     useradd bwrap-tester
     runcontainer
-    runuser -u bwrap-tester ./tests/test-run.sh
+    runuser -u bwrap-tester env ASAN_OPTIONS=detect_leaks=false ./tests/test-run.sh
 else
     buildinstall_to_host
 fi


### PR DESCRIPTION
If you read the logs, ASAN gets confused by us using PID namespaces.
Perhaps we could figure out an API to change this later, but in
the meantime, let's disable leak checks.

We still get use-after-free detection.