### PR TITLE
Remove privileged_op flags that are never used

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -848,7 +848,7 @@ setup_newroot (bool unshare_pid,
 
         case SETUP_REMOUNT_RO_NO_RECURSIVE:
           privileged_op (privileged_op_socket,
-                         PRIV_SEP_OP_REMOUNT_RO_NO_RECURSIVE, BIND_READONLY, NULL, dest);
+                         PRIV_SEP_OP_REMOUNT_RO_NO_RECURSIVE, 0, NULL, dest);
           break;
 
         case SETUP_MOUNT_PROC:
@@ -925,8 +925,7 @@ setup_newroot (bool unshare_pid,
             if (mkdir (pts, 0755) == -1)
               die_with_error ("Can't create %s/devpts", op->dest);
             privileged_op (privileged_op_socket,
-                           PRIV_SEP_OP_DEVPTS_MOUNT, BIND_DEVICES,
-                           pts, NULL);
+                           PRIV_SEP_OP_DEVPTS_MOUNT, 0, pts, NULL);
 
             if (symlink ("pts/ptmx", ptmx) != 0)
               die_with_error ("Can't make symlink at %s/ptmx", op->dest);


### PR DESCRIPTION
I've been repurposing bubblewrap and noticed that `flags` is ignored when mounting devpts in `privileged_op` (https://github.com/projectatomic/bubblewrap/blob/e605e2d/bubblewrap.c#L770-L774), but `BIND_DEVICES` is passed as a flag (https://github.com/projectatomic/bubblewrap/blob/e605e2d/bubblewrap.c#L927-L929) - fortunately it's ignored, as `BIND_DEVICES` only applies to `bind_mount` - passing it to `mount` would not be correct.

Similarly but less importantly, the call to `PRIV_SEP_OP_REMOUNT_RO_NO_RECURSIVE` passes `BIND_READONLY` as flags, but it doesn't need to as that's hardcoded inside `privileged_op`.