### PR TITLE
Correctly validate remount-ro argument

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1276,6 +1276,9 @@ parse_args_recurse (int    *argcp,
         }
       else if (strcmp (arg, "--remount-ro") == 0)
         {
+          if (argc < 2)
+            die ("--remount-ro takes one argument");
+
           SetupOp *op = setup_op_new (SETUP_REMOUNT_RO_NO_RECURSIVE);
           op->dest = argv[1];
 


### PR DESCRIPTION
Usually a `--remount-ro` without anything following is caught by the check that a command has been passed after the argument list. However you can try to exploit it by using `--args`, like so:
```
$ echo -en '--remount-ro' | ./bwrap --args 0 --bind / / ls
Can't remount readonly on (null): Invalid argument
```
Fortunately it just picks up the NULL sentinel set up by the handling of `--args`, and this just gets passed straight through to `mount` and `printf`, both of which check for NULL before dereferencing.