### PR TITLE
demos/shell: Use --die-with-parent

### DIFF
--- a/demos/bubblewrap-shell.sh
+++ b/demos/bubblewrap-shell.sh
@@ -23,6 +23,7 @@ set -euo pipefail
       --chdir / \
       --unshare-all \
       --share-net \
+      --die-with-parent \
       --dir /run/user/$(id -u) \
       --setenv XDG_RUNTIME_DIR "/run/user/`id -u`" \
       --setenv PS1 "bwrap-demo$ " \


### PR DESCRIPTION
As I said in the release notes, I think the majority of use cases want this,
which includes this interactive shell.