### PR TITLE
main: Squash a -Wunused-result error, enable FORTIFY_SOURCE in CI

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -18,8 +18,8 @@ timeout: 30m
 
 inherit: true
 
-context: f25-asan-ubsan
+context: f25-sanitizer
 required: true
 
 tests:
-  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address' ./ci/redhat-ci.sh fedora:25
+  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2' ./ci/redhat-ci.sh fedora:25

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2109,7 +2109,7 @@ main (int    argc,
   if (opt_block_fd != -1)
     {
       char b[1];
-      read (opt_block_fd, b, 1);
+      (void) TEMP_FAILURE_RETRY (read (opt_block_fd, b, 1));
       close (opt_block_fd);
     }
 


### PR DESCRIPTION
This apparently only is emitted with `CFLAGS='-O2 -Wp,-D_FORTIFY_SOURCE=2'`,
which is used by RPM builds in Fedora at least. Enable that by default.

Note that I fixed it by using `TEMP_FAILURE_RETRY`, which should also ensure
that we don't spuriously continue if the `read` was interrupted by `EINTR` for
some reason.