### PR TITLE
ci: rename files to new name and bump to f26

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -18,6 +18,9 @@ timeout: 30m
 
 inherit: true
 
+host:
+    distro: fedora/26/atomic
+
 context: f26-sanitizer
 required: true
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -10,7 +10,7 @@ host:
     distro: centos/7/atomic
 
 tests:
-  - env BWRAP_SUID=true ./ci/redhat-ci.sh centos:7
+  - env BWRAP_SUID=true ./ci/papr.sh centos:7
 
 timeout: 30m
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -18,8 +18,8 @@ timeout: 30m
 
 inherit: true
 
-context: f25-sanitizer
+context: f26-sanitizer
 required: true
 
 tests:
-  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2' ./ci/redhat-ci.sh fedora:25
+  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2' ./ci/papr.sh registry.fedoraproject.org/fedora:26

--- a/ci/papr.sh
+++ b/ci/papr.sh
@@ -5,7 +5,7 @@ set -xeuo pipefail
 distro=$1
 
 runcontainer() {
-    docker run --rm --env=container=true --env=BWRAP_SUID=${BWRAP_SUID:-} --env CFLAGS="${CFLAGS:-}" --net=host --privileged -v /usr:/host/usr -v $(pwd):/srv/code -w /srv/code $distro ./ci/redhat-ci.sh $distro
+    docker run --rm --env=container=true --env=BWRAP_SUID=${BWRAP_SUID:-} --env CFLAGS="${CFLAGS:-}" --net=host --privileged -v /usr:/host/usr -v $(pwd):/srv/code -w /srv/code $distro ./ci/papr.sh $distro
 }
 
 buildinstall_to_host() {
@@ -37,8 +37,6 @@ buildinstall_to_host() {
 
 if test -z "${container:-}"; then
     ostree admin unlock
-    # Hack until the host tree is updated in rhci
-    rpm -Uvh https://kojipkgs.fedoraproject.org//packages/glibc/2.24/4.fc25/x86_64/{libcrypt-nss,glibc,glibc-common,glibc-all-langpacks}-2.24-4.fc25.x86_64.rpm
     useradd bwrap-tester
     runcontainer
     runuser -u bwrap-tester env ASAN_OPTIONS=detect_leaks=false ./tests/test-run.sh

--- a/ci/papr.sh
+++ b/ci/papr.sh
@@ -12,7 +12,7 @@ buildinstall_to_host() {
 
     yum -y install git autoconf automake libtool make gcc redhat-rpm-config \
         libcap-devel  'pkgconfig(libselinux)' 'libxslt' 'docbook-style-xsl' \
-        lib{a,ub,t}san /usr/bin/eu-readelf
+        lib{a,ub,t}san /usr/bin/eu-readelf rsync
 
     echo testing: $(git describe --tags --always --abbrev=42)
 


### PR DESCRIPTION
Rename the YAML file and its auxiliary files to the newly supported
name and bump tests to use F26.