### PR TITLE
Retain all caps when invoked by uid 0

### DIFF
--- a/ci/papr.sh
+++ b/ci/papr.sh
@@ -39,7 +39,10 @@ if test -z "${container:-}"; then
     ostree admin unlock
     useradd bwrap-tester
     runcontainer
+    # Unprivileged invocation
     runuser -u bwrap-tester env ASAN_OPTIONS=detect_leaks=false ./tests/test-run.sh
+    # Privileged invocation
+    env ASAN_OPTIONS=detect_leaks=false ./tests/test-run.sh
 else
     buildinstall_to_host
 fi

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -31,9 +31,15 @@ for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=$(id -u) | a
     fi
 done
 
+if test "$(id -u)" = "0"; then
+    is_uidzero=true
+else
+    is_uidzero=false
+fi
+
 # This is supposed to be an otherwise readable file in an unreadable (by the user) dir
 UNREADABLE=/root/.bashrc
-if test -x `dirname $UNREADABLE`; then
+if ${is_uidzero} || test -x `dirname $UNREADABLE`; then
     UNREADABLE=
 fi
 
@@ -67,7 +73,7 @@ for ALT in "" "--unshare-user-try"  "--unshare-pid" "--unshare-user-try --unshar
         CAP=""
     fi
 
-    if $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow  /tmp/foo cat /etc/shadow; then
+    if ! ${is_uidzero} && $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow  /tmp/foo cat /etc/shadow; then
         assert_not_reached Could read /etc/shadow
     fi
     # Unreadable dir
@@ -86,11 +92,28 @@ done
 $RUN --unshare-pid --as-pid-1 --bind / / bash -c 'echo $$' > as_pid_1.txt
 assert_file_has_content as_pid_1.txt "1"
 
-# Check that by default we have no caps left
-for OPT in "" "--unshare-user-try --as-pid-1" "--unshare-user-try" "--as-pid-1"; do
-    $RUN $OPT --unshare-pid getpcaps 1 2> /tmp/caps
-    grep -q ": =$" /tmp/caps
-done
+if ! ${is_uidzero}; then
+    # When invoked as non-root, check that by default we have no caps left
+    for OPT in "" "--unshare-user-try --as-pid-1" "--unshare-user-try" "--as-pid-1"; do
+        $RUN $OPT --unshare-pid getpcaps 1 2> /tmp/caps
+        grep -q ": =$" /tmp/caps
+    done
+else
+    capsh --print > caps.orig
+    for OPT in "" "--as-pid-1"; do
+        $RUN $OPT --unshare-pid capsh --print >caps.test
+        diff -u caps.orig caps.test
+    done
+    # And test that we can drop all, as well as specific caps
+    $RUN $OPT --cap-drop ALL --unshare-pid capsh --print >caps.test
+    assert_file_has_content caps.test 'Current: =$'
+    # Check for dropping kill/fowner (we assume all uid 0 callers have this)
+    $RUN $OPT --cap-drop CAP_KILL --cap-drop CAP_FOWNER --unshare-pid capsh --print >caps.test
+    assert_not_file_has_content caps.test '^Current: =.*cap_kill'
+    assert_not_file_has_content caps.test '^Current: =.*cap_fowner'
+    # But we should still have net_bind_service for example
+    assert_file_has_content caps.test '^Current: =.*cap_net_bind_service'
+fi
 
 # Test --die-with-parent
 


### PR DESCRIPTION
In <https://github.com/projectatomic/bubblewrap/pull/101>, specifically
commit cde7fab7ec4aafd9386a41e2e10a6af07fda3eb8 we started dropping
all capabilities, even if the caller was privileged.

This broke rpm-ostree, which runs RPM scripts using bwrap, and some
of those scripts depend on capabilities (mostly `CAP_DAC_OVERRIDE`).

Fix this by retaining capabilities by default if the caller's uid is zero.

I considered having the logic be to simply retain any capabilities the invoking
process has (imagine filecaps binaries like `ping` or
`/usr/bin/gnome-keyring-daemon` using bwrap) but we currently explicitly abort
in that scenario to catch broken packages which used file capabilites for bwrap
itself (we switched to suid). For now this works, and if down the line there's a
real-world use case for capability-bearing non-zero-uid processes to invoke
bwrap *and* retain those privileges, we can revisit.

Closes: https://github.com/projectatomic/bubblewrap/issues/197