### PR TITLE
With --dev, add /dev/fd and /dev/core symlinks

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1046,6 +1046,16 @@ setup_newroot (bool unshare_pid,
                 die_with_error ("Can't create symlink %s/%s", op->dest, stdionodes[i]);
             }
 
+          /* /dev/fd and /dev/core - legacy, but both nspawn and docker do these */
+          { cleanup_free char *dev_fd = strconcat (dest, "/fd");
+            if (symlink ("/proc/self/fd", dev_fd) < 0)
+              die_with_error ("Can't create symlink %s", dev_fd);
+          }
+          { cleanup_free char *dev_core = strconcat (dest, "/core");
+            if (symlink ("/proc/kcore", dev_core) < 0)
+              die_with_error ("Can't create symlink %s", dev_core);
+          }
+
           {
             cleanup_free char *pts = strconcat (dest, "/pts");
             cleanup_free char *ptmx = strconcat (dest, "/ptmx");

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -88,6 +88,9 @@ for ALT in "" "--unshare-user-try"  "--unshare-pid" "--unshare-user-try --unshar
     $RUN $ALT --dir /tmp/dir --symlink dir /tmp/link --bind /etc /tmp/link true
 done
 
+# Test devices
+$RUN --unshare-pid --dev /dev ls -al /dev/{stdin,stdout,stderr,null,random,urandom,fd,core} >/dev/null
+
 # Test --as-pid-1
 $RUN --unshare-pid --as-pid-1 --bind / / bash -c 'echo $$' > as_pid_1.txt
 assert_file_has_content as_pid_1.txt "1"


### PR DESCRIPTION
`systemd-nspawn` and `docker` at least both have these by default;
the only difference AFAICS now is that nspawn also adds `/dev/mqueue`
by default, but we require a separate arg for that.

This should increase compatibility with apps using the `/dev/fd`.

Closes: https://github.com/projectatomic/bubblewrap/issues/191