### PR TITLE
bubblewrap: check for max_user_namespaces == 0

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1988,6 +1988,15 @@ main (int    argc,
             disabled = TRUE;
         }
 
+      /* Check for max_user_namespaces */
+      if (stat ("/proc/sys/user/max_user_namespaces", &sbuf) == 0)
+        {
+          cleanup_free char *max_user_ns = NULL;
+          max_user_ns = load_file_at (AT_FDCWD, "/proc/sys/user/max_user_namespaces");
+          if (max_user_ns != NULL && strcmp(max_user_ns, "0\n") == 0)
+            disabled = TRUE;
+        }
+
       /* Debian lets you disable *unprivileged* user namespaces. However this is not
          a problem if we're privileged, and if we're not opt_unshare_user is TRUE
          already, and there is not much we can do, its just a non-working setup. */


### PR DESCRIPTION
It seems like the recent CentOS 7.4 kernel replaced the
/sys/module/user_namespace/parameters/enable file by
setting this sysctl user.max_user_namespaces = 0.

This change prevents bubblewrap to use userns when the
max_user_namespaces is set to 0.