### PR TITLE
bubblewrap: Remove not needed MS_MGC_VAL mount flag

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -389,7 +389,7 @@ bind_mount (int           proc_fd,
 
   if (src)
     {
-      if (mount (src, dest, NULL, MS_MGC_VAL | MS_BIND | (recursive ? MS_REC : 0), NULL) != 0)
+      if (mount (src, dest, NULL, MS_BIND | (recursive ? MS_REC : 0), NULL) != 0)
         return 1;
     }
 
@@ -411,7 +411,7 @@ bind_mount (int           proc_fd,
   new_flags = current_flags | (devices ? 0 : MS_NODEV) | MS_NOSUID | (readonly ? MS_RDONLY : 0);
   if (new_flags != current_flags &&
       mount ("none", resolved_dest,
-             NULL, MS_MGC_VAL | MS_BIND | MS_REMOUNT | new_flags, NULL) != 0)
+             NULL, MS_BIND | MS_REMOUNT | new_flags, NULL) != 0)
     return 3;
 
   /* We need to work around the fact that a bind mount does not apply the flags, so we need to manually
@@ -426,7 +426,7 @@ bind_mount (int           proc_fd,
           new_flags = current_flags | (devices ? 0 : MS_NODEV) | MS_NOSUID | (readonly ? MS_RDONLY : 0);
           if (new_flags != current_flags &&
               mount ("none", mount_tab[i].mountpoint,
-                     NULL, MS_MGC_VAL | MS_BIND | MS_REMOUNT | new_flags, NULL) != 0)
+                     NULL, MS_BIND | MS_REMOUNT | new_flags, NULL) != 0)
             {
               /* If we can't read the mountpoint we can't remount it, but that should
                  be safe to ignore because its not something the user can access. */

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -896,20 +896,20 @@ privileged_op (int         privileged_op_socket,
       break;
 
     case PRIV_SEP_OP_PROC_MOUNT:
-      if (mount ("proc", arg1, "proc", MS_MGC_VAL | MS_NOSUID | MS_NOEXEC | MS_NODEV, NULL) != 0)
+      if (mount ("proc", arg1, "proc", MS_NOSUID | MS_NOEXEC | MS_NODEV, NULL) != 0)
         die_with_error ("Can't mount proc on %s", arg1);
       break;
 
     case PRIV_SEP_OP_TMPFS_MOUNT:
       {
         cleanup_free char *opt = label_mount ("mode=0755", opt_file_label);
-        if (mount ("tmpfs", arg1, "tmpfs", MS_MGC_VAL | MS_NOSUID | MS_NODEV, opt) != 0)
+        if (mount ("tmpfs", arg1, "tmpfs", MS_NOSUID | MS_NODEV, opt) != 0)
           die_with_error ("Can't mount tmpfs on %s", arg1);
         break;
       }
 
     case PRIV_SEP_OP_DEVPTS_MOUNT:
-      if (mount ("devpts", arg1, "devpts", MS_MGC_VAL | MS_NOSUID | MS_NOEXEC,
+      if (mount ("devpts", arg1, "devpts", MS_NOSUID | MS_NOEXEC,
                  "newinstance,ptmxmode=0666,mode=620") != 0)
         die_with_error ("Can't mount devpts on %s", arg1);
       break;


### PR DESCRIPTION
As specified by mount(2):

	Specifying MS_MGC_VAL was required in kernel versions prior to 2.4, but
	since Linux 2.4 is no longer required and is ignored if specified.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>