### PR TITLE
Avoid leaking --args-fd to child process

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1333,6 +1333,7 @@ parse_args_recurse (int          *argcp,
           data = load_file_data (the_fd, &data_len);
           if (data == NULL)
             die_with_error ("Can't read --args data");
+          (void) close (the_fd);
 
           data_end = data + data_len;
           data_argc = 0;


### PR DESCRIPTION
I was looking at what fds flatpak injects, and realized this is actually just a
bubblewrap bug; there's no reason for us to leak this to the child, so don't.

It took me a while to work out/remember that our `close_extra_fds()` bits are
only intended to handle processes *other* than the final target, i.e. we want to
close fds in our init process. For the final child process, we need to support
passing arbitrary fds though, so `close_extra_fds()` can't apply to the child.