### PR TITLE
 main: Add --exec-filename option to execute instead of argv[0]

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -192,6 +192,10 @@
       <listitem><para>Bind mount the host path <arg choice="plain">SRC</arg> readonly on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--exec-filename <arg choice="plain">PATH</arg></option></term>
+      <listitem><para>Path to the application to be executed inside the sandbox</para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--remount-ro <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Remount the path <arg choice="plain">DEST</arg> as readonly.  It works only on the specified mount point, without changing any other mount point under the specified path</para></listitem>
     </varlistentry>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -31,6 +31,7 @@ _bwrap() {
 		--dev
 		--dev-bind
 		--dir
+		--exec-filename
 		--exec-label
 		--file
 		--file-label

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -162,4 +162,13 @@ for die_with_parent_argv in "--die-with-parent" "--die-with-parent --unshare-pid
     echo "ok die with parent ${die_with_parent_argv}"
 done
 
+RUN="${BWRAP} --bind / / python3 -c "
+# Check executable name
+$RUN "import sys; print(sys.executable)" >python3_output.txt
+assert_file_has_content python3_output.txt "python3"
+
+RUN="${BWRAP} --bind / / --exec-filename python3 bash -c "
+$RUN "import sys; print(sys.executable)" >python3_output.txt
+assert_file_has_content python3_output.txt "bash"
+
 echo OK


### PR DESCRIPTION
For now, both --argv0 and the current argv0 (as last parameter of bwrap
call) are supported.

Closes: #91

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>