### PR TITLE
tests: Fix a race condition between attempts to lock a file

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -140,7 +140,10 @@ chmod a+x lockf-n.py
 touch lock
 
 for die_with_parent_argv in "--die-with-parent" "--die-with-parent --unshare-pid"; do
-    /bin/bash -c "$RUN ${die_with_parent_argv} --lock-file $(pwd)/lock sleep 1h && true" &
+    # We have to loop here, because bwrap doesn't wait for the lock if
+    # another process is holding it. If we're unlucky, lockf-n.py will
+    # be holding it.
+    /bin/bash -c "while true; do $RUN ${die_with_parent_argv} --lock-file $(pwd)/lock sleep 1h; done" &
     childshellpid=$!
 
     # Wait for lock to be taken (yes hacky)


### PR DESCRIPTION
bwrap uses F_SETLK, not F_SETLKW, to implement --lock-file.
This means we have to be prepared to retry if another process -
like our own lockf-n.py - might already be holding it.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

See also #226 which wonders whether this is intentional.