### PR TITLE
tests: Ensure non-root users have access to libcap tools

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -2,6 +2,9 @@
 
 set -xeuo pipefail
 
+# Make sure /sbin/getpcaps etc. are in our PATH even if non-root
+PATH="$PATH:/usr/sbin:/sbin"
+
 srcd=$(cd $(dirname $0) && pwd)
 
 . ${srcd}/libtest-core.sh


### PR DESCRIPTION
On Debian systems, by default only root has /{usr/,}sbin in PATH.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

I tried packaging bubblewrap git master for Debian experimental (to have early-warning if it's going to break Flatpak) and ran into this with the new capabilities test coverage.