### PR TITLE
Release 0.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([bubblewrap], [0.1.8], [atomic-devel@projectatomic.io])
+AC_INIT([bubblewrap], [0.2.0], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
We've got a lot of new features and bugfixes since 0.1.8. Let's cut a new
release before we start landing even more things like the `pivot_root()` PR.