### PR TITLE
Prefix error messages with program name

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -113,6 +113,13 @@ $RUN --unshare-pid --as-pid-1 --bind / / bash -c 'echo $$' > as_pid_1.txt
 assert_file_has_content as_pid_1.txt "1"
 echo "ok - can run as pid 1"
 
+# Test error prefixing
+if $RUN --unshare-pid  --bind /source-enoent /dest true 2>err.txt; then
+    assert_not_reached "bound nonexistent source"
+fi
+assert_file_has_content err.txt "^bwrap: Can't find source path.*source-enoent"
+echo "ok error prefxing"
+
 if ! ${is_uidzero}; then
     # When invoked as non-root, check that by default we have no caps left
     for OPT in "" "--unshare-user-try --as-pid-1" "--unshare-user-try" "--as-pid-1"; do

--- a/utils.c
+++ b/utils.c
@@ -29,6 +29,8 @@ die_with_error (const char *format, ...)
   va_list args;
   int errsv;
 
+  fprintf (stderr, "bwrap: ");
+
   errsv = errno;
 
   va_start (args, format);
@@ -44,6 +46,8 @@ void
 die (const char *format, ...)
 {
   va_list args;
+
+  fprintf (stderr, "bwrap: ");
 
   va_start (args, format);
   vfprintf (stderr, format, args);


### PR DESCRIPTION
It may not always be obvious what the source of any particular error
message is. For instance, "Can't find source path" errors could be
perceived as coming from either the shell, loader, bubblewrap, or the
wrapped application, especially when a previously-configured program
stops working due to some external circumstances.

Thus, disambiguate the source of bubblewrap's error messages by
printing them with a "bwrap: " prefix.