### PR TITLE
build: Include various interesting files in tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,18 @@
 AM_CFLAGS = $(WARN_CFLAGS)
 CLEANFILES =
-EXTRA_DIST =
+EXTRA_DIST = \
+	.dir-locals.el \
+	.editorconfig \
+	README.md \
+	autogen.sh \
+	demos/bubblewrap-shell.sh \
+	demos/flatpak-run.sh \
+	demos/flatpak.bpf \
+	demos/userns-block-fd.py \
+	packaging/bubblewrap.spec \
+	uncrustify.cfg \
+	uncrustify.sh \
+	$(NULL)
 
 GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 


### PR DESCRIPTION
README.md and the demos are documentation that could be useful to
install, the spec file can be used by rpmbuild -ta, and the autogen.sh
and editor and uncrustify configuration could be useful for distro
packagers contributing patches upstream from a tree based on tarball
imports.

I arbitrarily left out CI configuration for PAPR and Travis-CI, since
these always take their source code from git anyway.

git.mk is excluded because it contains comments saying it should be.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

Until now I've been using GitHub's `git export` tarballs, because the first few bubblewrap releases only had those; but the last few releases came with `make dist` tarballs, and Debian policy is to prefer using an upstream's official tarball release if they have one. However, that would mean losing `README.md` and the examples, which we currently put in `/usr/share/doc`.

I'm happy to adjust the list of included files if you don't like this version, although if we don't include `README.md` and the examples, I'll have to either patch them back in or stop packaging them.