### PR TITLE
bwrap: Second attempt at fixing an argv handling leak

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -53,7 +53,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..32"
+echo "1..33"
 
 # Test help
 ${BWRAP} --help > help.txt


### PR DESCRIPTION
The first attempt caused a use-after-free because the arguments parsed
from --args are passed to parse_args_recurse(), and the other cases
there may take those pointers (without copying) into SetupOp structures,
which persist after data is freed.

Fix that by treating data more like the argv to main(): an allocation
which exists throughout the life of the program. Do that by hoisting its
declaration out as a global, and then pulling the allocated data into a
cleanup_free variable in main(), to tie its lifecycle to main().

The alternative is to strdup() each one of the argv elements when they
are used in parse_args_recurse(), but that would mean a lot more
allocations and frees, and a lot of code churn.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://github.com/projectatomic/bubblewrap/issues/224