### PR TITLE
Remove --nonet from xsltproc invocation

### DIFF
--- a/Makefile-docs.am
+++ b/Makefile-docs.am
@@ -1,7 +1,6 @@
 XSLTPROC = xsltproc
 
 XSLTPROC_FLAGS = \
-	--nonet \
 	--stringparam man.output.quietly 1 \
 	--stringparam funcsynopsis.style ansi \
 	--stringparam man.th.extra1.suppress 1 \


### PR DESCRIPTION
When building the man page xsltproc is used and with the --nonet flag
fails with:

  I/O error : Attempt to load network entity http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl

This is because it is attempting to load the docbook.xsl from
sourcefourge but we've told it it can't use the network. This breaks a
default invocation of `make` in addition to building the manpage (as
make will attempt to build the manpage).

Fix this by simply removing --nonet.