### PR TITLE
continuation of "support recursive bwrap" : #172

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2295,6 +2295,9 @@ main (int    argc,
   if (mkdir ("newroot", 0755))
     die_with_error ("Creating newroot failed");
 
+  if (mount ("newroot", "newroot", NULL, MS_MGC_VAL | MS_BIND | MS_REC, NULL) < 0)
+    die_with_error ("setting up newroot bind");
+
   if (mkdir ("oldroot", 0755))
     die_with_error ("Creating oldroot failed");
 

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2371,7 +2371,7 @@ main (int    argc,
     if (mkdtemp (pivot_tmp) == NULL)
       {
         /* If the user did a bind mount of /, try /tmp */
-        if (errno == EPERM || errno == EACCES)
+        if (errno == EROFS || errno == EPERM || errno == EACCES)
           {
             free (pivot_tmp);
             pivot_tmp = xstrdup ("tmp/bwrap-pivot-old-XXXXXX");

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2357,6 +2357,40 @@ main (int    argc,
   if (umount2 ("oldroot", MNT_DETACH))
     die_with_error ("unmount old root");
 
+  /* This is our second pivot. It's like we're a Silicon Valley startup flush
+   * with cash but short on ideas!
+   *
+   * We're aiming to make /newroot the real root, and get rid of /oldroot. To do
+   * that we need a temporary place to store it before we can unmount it.
+   */
+  { cleanup_free char *pivot_tmp = xstrdup ("bwrap-pivot-old-XXXXXX");
+    if (mount ("/newroot", "/newroot", NULL, MS_MGC_VAL | MS_BIND | MS_REC, NULL) < 0)
+      die_with_error ("setting up newroot bind");
+    if (chdir ("/newroot") != 0)
+      die_with_error ("chdir /newroot");
+    if (mkdtemp (pivot_tmp) == NULL)
+      {
+        /* If the user did a bind mount of /, try /tmp */
+        if (errno == EPERM || errno == EACCES)
+          {
+            free (pivot_tmp);
+            pivot_tmp = xstrdup ("tmp/bwrap-pivot-old-XXXXXX");
+            if (mkdtemp (pivot_tmp) == NULL)
+              die_with_error ("mkdtemp");
+          }
+        else
+          die_with_error ("mkdtemp");
+      }
+    if (pivot_root (".", pivot_tmp) != 0)
+      die_with_error ("pivot_root(/newroot)");
+    if (chroot (".") != 0)
+      die_with_error ("chroot .");
+    if (chdir ("/") != 0)
+      die_with_error ("chdir /");
+    if (umount2 (pivot_tmp, MNT_DETACH) < 0)
+      die_with_error ("unmount old root");
+  }
+
   if (opt_unshare_user &&
       (ns_uid != opt_sandbox_uid || ns_gid != opt_sandbox_gid) &&
       opt_userns_block_fd == -1)
@@ -2372,14 +2406,6 @@ main (int    argc,
                          opt_sandbox_gid, ns_gid,
                          -1, FALSE, FALSE);
     }
-
-  /* Now make /newroot the real root */
-  if (chdir ("/newroot") != 0)
-    die_with_error ("chdir newroot");
-  if (chroot ("/newroot") != 0)
-    die_with_error ("chroot /newroot");
-  if (chdir ("/") != 0)
-    die_with_error ("chdir /");
 
   /* All privileged ops are done now, so drop caps we don't need */
   drop_privs (!is_privileged);

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1020,20 +1020,23 @@ setup_newroot (bool unshare_pid,
           /* There are a bunch of weird old subdirs of /proc that could potentially be
              problematic (for instance /proc/sysrq-trigger lets you shut down the machine
              if you have write access). We should not have access to these as a non-privileged
-             user, but lets cover them anyway if we have no CAP_SYS_ADMIN just to make sure */
-          if (!opt_cap_add_or_drop_used || !(requested_caps[0] & CAP_TO_MASK_0 (CAP_SYS_ADMIN)))
+             user, but lets cover them anyway just to make sure */
+          const char *cover_proc_dirs[] = { "sys", "sysrq-trigger", "irq", "bus" };
+          for (i = 0; i < N_ELEMENTS (cover_proc_dirs); i++)
             {
-              const char *cover_proc_dirs[] = { "sys", "sysrq-trigger", "irq", "bus" };
-              for (i = 0; i < N_ELEMENTS (cover_proc_dirs); i++)
+              cleanup_free char *subdir = strconcat3 (dest, "/", cover_proc_dirs[i]);
+              if (access (subdir, W_OK) < 0)
                 {
-                  cleanup_free char *subdir = strconcat3 (dest, "/", cover_proc_dirs[i]);
-                  /* Some of these may not exist */
-                  if (get_file_mode (subdir) == -1)
+                  /* The file is already read-only or doesn't exist.  */
+                  if (errno == EACCES || errno == ENOENT)
                     continue;
-                  privileged_op (privileged_op_socket,
-                                 PRIV_SEP_OP_BIND_MOUNT, BIND_READONLY,
-                                 subdir, subdir);
+
+                  die_with_error ("Can't access %s", subdir);
                 }
+
+              privileged_op (privileged_op_socket,
+                             PRIV_SEP_OP_BIND_MOUNT, BIND_READONLY,
+                             subdir, subdir);
             }
 
           break;

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2372,10 +2372,18 @@ main (int    argc,
   { cleanup_fd int oldrootfd = open ("/", O_DIRECTORY | O_RDONLY);
     if (oldrootfd < 0)
       die_with_error ("can't open /");
-    if (mount ("/newroot", "/newroot", NULL, MS_MGC_VAL | MS_BIND | MS_REC, NULL) < 0)
-      die_with_error ("setting up newroot bind");
     if (chdir ("/newroot") != 0)
       die_with_error ("chdir /newroot");
+    /* While the documentation claims that put_old must be underneath
+     * new_root, it is perfectly fine to use the same directory as the
+     * kernel checks only if old_root is accessible from new_root.
+     *
+     * Both runc and LXC are using this "alternative" method for
+     * setting up the root of the container:
+     *
+     * https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L671
+     * https://github.com/lxc/lxc/blob/master/src/lxc/conf.c#L1121
+     */
     if (pivot_root (".", ".") != 0)
       die_with_error ("pivot_root(/newroot)");
     if (fchdir (oldrootfd) < 0)

--- a/ci/papr.sh
+++ b/ci/papr.sh
@@ -29,7 +29,7 @@ buildinstall_to_host() {
         fi
     done
     rsync -rlv ${tmpd}/usr/ /host/usr/
-    if ${BWRAP_SUID}; then
+    if -n "${BWRAP_SUID:-}"; then
         chmod u+s /host/usr/bin/bwrap
     fi
     rm ${tmpd} -rf

--- a/ci/papr.sh
+++ b/ci/papr.sh
@@ -29,7 +29,7 @@ buildinstall_to_host() {
         fi
     done
     rsync -rlv ${tmpd}/usr/ /host/usr/
-    if -n "${BWRAP_SUID:-}"; then
+    if test -n "${BWRAP_SUID:-}"; then
         chmod u+s /host/usr/bin/bwrap
     fi
     rm ${tmpd} -rf

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,6 +24,9 @@ trap cleanup EXIT
 cd ${tempdir}
 
 : "${BWRAP:=bwrap}"
+if test -u "$(type -p ${BWRAP})"; then
+    bwrap_is_suid=true
+fi
 
 FUSE_DIR=
 for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=$(id -u) | awk '{print $2}'); do
@@ -89,7 +92,7 @@ for ALT in "" "--unshare-user-try"  "--unshare-pid" "--unshare-user-try --unshar
     echo -n "expect EPERM: " >&2
 
     # Test caps when bwrap is not setuid
-    if ! test -u ${BWRAP}; then
+    if test -n "${bwrap_is_suid:-}"; then
         CAP="--cap-add ALL"
     else
         CAP=""
@@ -125,7 +128,7 @@ assert_file_has_content as_pid_1.txt "1"
 echo "ok - can run as pid 1"
 
 # These tests require --unshare-user
-if test -u ${BWRAP}; then
+if test -n "${bwrap_is_suid:-}"; then
     echo "ok - # SKIP no --cap-add support"
     echo "ok - # SKIP no --cap-add support"
 else

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -64,7 +64,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..37"
+echo "1..38"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -129,8 +129,8 @@ $BWRAP_RECURSE -- $BWRAP --unshare-all --bind / / --proc /proc echo hello > recu
 assert_file_has_content recursive_proc.txt "hello"
 echo "ok - can mount /proc recursively"
 
-$BWRAP_RECURSE -- $BWRAP --unshare-all  ${BWRAP_RO_HOST_ARGS} /proc echo hello > recursive_proc.txt
-assert_file_has_content recursive_proc.txt "hello"
+$BWRAP_RECURSE -- $BWRAP --unshare-all  ${BWRAP_RO_HOST_ARGS} findmnt > recursive-newroot.txt
+assert_file_has_content recursive-newroot.txt "/usr"
 echo "ok - can pivot to new rootfs recursively"
 
 # Test error prefixing

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -53,7 +53,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..36"
+echo "1..37"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -112,6 +112,15 @@ echo "ok - all expected devices were created"
 $RUN --unshare-pid --as-pid-1 --bind / / bash -c 'echo $$' > as_pid_1.txt
 assert_file_has_content as_pid_1.txt "1"
 echo "ok - can run as pid 1"
+
+if ! test -u ${BWRAP}; then
+    echo "ok - # SKIP no --cap-add support"
+else
+    $BWRAP --unshare-all --uid 0 --gid 0 --cap-add ALL --bind / / --proc /proc \
+           $BWRAP --unshare-all --bind / / --proc /proc echo hello > recursive_proc.txt
+    assert_file_has_content recursive_proc.txt "hello"
+    echo "ok - can mount /proc recursively"
+fi
 
 # Test error prefixing
 if $RUN --unshare-pid  --bind /source-enoent /dest true 2>err.txt; then


### PR DESCRIPTION
continuation of https://github.com/projectatomic/bubblewrap/pull/172

I've added a fixup patch and a patch to handle recursive pid namespaces to mount`/proc` recursively