### PR TITLE
Don't rely on mkdir returning EEXISTS (fixing NFS)

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -980,7 +980,7 @@ setup_newroot (bool unshare_pid,
         case SETUP_BIND_MOUNT:
           if (source_mode == S_IFDIR)
             {
-              if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+              if (ensure_dir (dest, 0755) != 0)
                 die_with_error ("Can't mkdir %s", op->dest);
             }
           else if (ensure_file (dest, 0666) != 0)
@@ -999,7 +999,7 @@ setup_newroot (bool unshare_pid,
           break;
 
         case SETUP_MOUNT_PROC:
-          if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          if (ensure_dir (dest, 0755) != 0)
             die_with_error ("Can't mkdir %s", op->dest);
 
           if (unshare_pid)
@@ -1036,7 +1036,7 @@ setup_newroot (bool unshare_pid,
           break;
 
         case SETUP_MOUNT_DEV:
-          if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          if (ensure_dir (dest, 0755) != 0)
             die_with_error ("Can't mkdir %s", op->dest);
 
           privileged_op (privileged_op_socket,
@@ -1112,7 +1112,7 @@ setup_newroot (bool unshare_pid,
           break;
 
         case SETUP_MOUNT_TMPFS:
-          if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          if (ensure_dir (dest, 0755) != 0)
             die_with_error ("Can't mkdir %s", op->dest);
 
           privileged_op (privileged_op_socket,
@@ -1121,7 +1121,7 @@ setup_newroot (bool unshare_pid,
           break;
 
         case SETUP_MOUNT_MQUEUE:
-          if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          if (ensure_dir (dest, 0755) != 0)
             die_with_error ("Can't mkdir %s", op->dest);
 
           privileged_op (privileged_op_socket,
@@ -1130,7 +1130,7 @@ setup_newroot (bool unshare_pid,
           break;
 
         case SETUP_MAKE_DIR:
-          if (mkdir (dest, 0755) != 0 && errno != EEXIST)
+          if (ensure_dir (dest, 0755) != 0)
             die_with_error ("Can't mkdir %s", op->dest);
 
           break;
@@ -2081,11 +2081,11 @@ main (int    argc,
   /* We need *some* mountpoint where we can mount the root tmpfs.
      We first try in /run, and if that fails, try in /tmp. */
   base_path = xasprintf ("/run/user/%d/.bubblewrap", real_uid);
-  if (mkdir (base_path, 0755) && errno != EEXIST)
+  if (ensure_dir (base_path, 0755))
     {
       free (base_path);
       base_path = xasprintf ("/tmp/.bubblewrap-%d", real_uid);
-      if (mkdir (base_path, 0755) && errno != EEXIST)
+      if (ensure_dir (base_path, 0755))
         die_with_error ("Creating root mountpoint failed");
     }
 

--- a/utils.h
+++ b/utils.h
@@ -101,6 +101,8 @@ int   create_file (const char *path,
                    const char *content);
 int   ensure_file (const char *path,
                    mode_t      mode);
+int   ensure_dir (const char *path,
+                  mode_t      mode);
 int   get_file_mode (const char *pathname);
 int   mkdir_with_parents (const char *pathname,
                           int         mode,


### PR DESCRIPTION
For NFS mounts if we call mkdir() on a read-only mount (such as when
we've created a read-only bind mount) the kernel will nor return EEXIST
even when the directory exists, instead returning EROFS.

So, we add (and use) an ensure_dir() helper that stats before calling
mkdir.

This fixes flatpak when storing the apps on an NFS filesystem.