### PR TITLE
Add "--" pseudo-argument to end option parsing

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -182,7 +182,7 @@ lock_file_new (const char *path)
 static void
 usage (int ecode, FILE *out)
 {
-  fprintf (out, "usage: %s [OPTIONS...] COMMAND [ARGS...]\n\n", argv0);
+  fprintf (out, "usage: %s [OPTIONS...] [--] COMMAND [ARGS...]\n\n", argv0);
 
   fprintf (out,
            "    --help                       Print this help\n"
@@ -1884,6 +1884,12 @@ parse_args_recurse (int          *argcp,
 
           argv += 1;
           argc -= 1;
+        }
+      else if (strcmp (arg, "--") == 0)
+        {
+          argv += 1;
+          argc -= 1;
+          break;
         }
       else if (*arg == '-')
         {


### PR DESCRIPTION
This shouldn't matter unless someone wants to run an inadvisably-named
executable, but it's best-practice for commands that pass on some
of their arguments to a subsequent command.
    
It allows an invocation like:
    
    bwrap --ro-bind /container / -- "$@"
    
to search PATH in the container for an executable named according to
"$1", even if $1 has a pathological value like
"--this-has-a-stupid-name--", or even a value that might be
deliberately trying to break bwrap's parsing like "--bind".

---

(Commit message edited to reflect @AltGr's concerns on #259)