### PR TITLE
Allow binding pre-existing sockets in the sandbox

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -71,7 +71,7 @@ bool opt_die_with_parent = FALSE;
 uid_t opt_sandbox_uid = -1;
 gid_t opt_sandbox_gid = -1;
 int opt_sync_fd = -1;
-int opt_close_fd = -1;
+int opt_notify_complete_fd = -1;
 int opt_block_fd = -1;
 int opt_userns_block_fd = -1;
 int opt_info_fd = -1;
@@ -209,7 +209,7 @@ usage (int ecode, FILE *out)
            "    --unsetenv VAR               Unset an environment variable\n"
            "    --lock-file DEST             Take a lock on DEST while sandbox is running\n"
            "    --sync-fd FD                 Keep this fd open while sandbox is running\n"
-           "    --close-fd FD                Close this fd when sandbox setup is done\n"
+           "    --notify-complete-fd FD      Close this fd when sandbox setup is done, signaling to the parent\n"
            "    --bind SRC DEST              Bind mount the host path SRC on DEST\n"
            "    --dev-bind SRC DEST          Bind mount the host path SRC on DEST, allowing device access\n"
            "    --ro-bind SRC DEST           Bind mount the host path SRC readonly on DEST\n"
@@ -1747,7 +1747,7 @@ parse_args_recurse (int          *argcp,
           if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
             die ("Invalid fd: %s", argv[1]);
 
-          opt_close_fd = the_fd;
+          opt_notify_complete_fd = the_fd;
 
           argv += 1;
           argc -= 1;
@@ -2248,8 +2248,8 @@ main (int    argc,
       /* Optionally bind our lifecycle to that of the parent */
       handle_die_with_parent ();
 
-      if (opt_close_fd != -1)
-        close (opt_close_fd);
+      if (opt_notify_complete_fd != -1)
+        close (opt_notify_complete_fd);
 
       if (opt_info_fd != -1)
         {
@@ -2480,8 +2480,8 @@ main (int    argc,
   /* All privileged ops are done now, so drop caps we don't need */
   drop_privs (!is_privileged);
 
-  if (opt_close_fd != -1)
-    close (opt_close_fd);
+  if (opt_notify_complete_fd != -1)
+    close (opt_notify_complete_fd);
 
   if (opt_block_fd != -1)
     {


### PR DESCRIPTION
Currently the flatpak dbus-proxy sockets are set up completely outside bwrap with a temporary filename, which is then bind-mounted into the sandbox.

For cleanness and to avoid leaking temp files in the error case I would like to instead create a socket() ahead of time and pass it to bubblewrap to bind() into place, so that it is never visible outside the sandbox.

Socket setup happens in phases:
1. Create the socket
2. Bind to a pathname
3. Listen, to allow the kernel to queue up connecting peers
4. accept, called by the service to receive new connections

These must happen in this order. For instance, we can't bind before listen, or accept before listen.

This is a bit complicated, because in our usecase these must happen in very different places.  1 happens in flatpak run, 2 happens in bwrap, and 4 happens in dbus-proxy.

This means we must additionally have a synchronization mechanism between dbus-proxy and bwrap so that we can avoid starting/accepting on the proxy until the sandbox is set up and all sockets are bound.

There is also the question where 3 should happen. In order to avoid a race condition where the dbus-proxy has not started accepting, but the socket is bound in the sandbox I put the listen() call in bwrap, because then any such connections will be queued by the kernel until dbus-proxy gets to them.

@smcv this would also be needed for bubblewrap to work with the new dbus container apis
