### PR TITLE
Use "tmpfs" instead of empty string for mount

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2280,7 +2280,7 @@ main (int    argc,
     die_with_error ("Failed to make / slave");
 
   /* Create a tmpfs which we will use as / in the namespace */
-  if (mount ("", base_path, "tmpfs", MS_NODEV | MS_NOSUID, NULL) != 0)
+  if (mount ("tmpfs", base_path, "tmpfs", MS_NODEV | MS_NOSUID, NULL) != 0)
     die_with_error ("Failed to mount tmpfs");
 
   old_cwd = get_current_dir_name ();


### PR DESCRIPTION
The empty string provokes kernel bugs:
https://marc.info/?l=linux-fsdevel&m=153138504004854&w=2

And we were using "tmpfs" for the other tmpfs mount path.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1599954