### PR TITLE
Add --bind-try options

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -184,12 +184,24 @@
       <listitem><para>Bind mount the host path <arg choice="plain">SRC</arg> on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--bind-try <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Equal to <option>--bind</option> but ignores non-existant <arg choice="plain">SRC</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--dev-bind <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Bind mount the host path <arg choice="plain">SRC</arg> on <arg choice="plain">DEST</arg>, allowing device access</para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--dev-bind-try <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Equal to <option>--dev-bind</option> but ignores non-existant <arg choice="plain">SRC</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--ro-bind <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Bind mount the host path <arg choice="plain">SRC</arg> readonly on <arg choice="plain">DEST</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--ro-bind-try <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Equal to <option>--ro-bind</option> but ignores non-existant <arg choice="plain">SRC</arg></para></listitem>
     </varlistentry>
     <varlistentry>
       <term><option>--remount-ro <arg choice="plain">DEST</arg></option></term>


### PR DESCRIPTION
These ignore source files not existing which allows bwrap using applications to avoid repeatedly checking if files exist.