### PR TITLE
Make lockdata long enough on 32-bit with 64-bit file pointers.

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -187,7 +187,7 @@ if sys.argv[2] == 'wait':
   locktype = fcntl.F_SETLKW
 else:
   locktype = fcntl.F_SETLK
-lockdata = struct.pack("hhllhh", fcntl.F_WRLCK, 0, 0, 0, 0, 0)
+lockdata = struct.pack("hhqqhh", fcntl.F_WRLCK, 0, 0, 0, 0, 0)
 fd=open(sys.argv[1], 'a')
 try:
   fcntl.fcntl(fd.fileno(), locktype, lockdata)


### PR DESCRIPTION
If python is compiled with 32-bit long and 64-bit file pointers, which is typical on 32-bit Linux, fcntl64 was being called with garbage.

Setting the type to long long ("q") has no effect on 64-bit Linux as sizeof(long long) == sizeof(long) and is harmlessly too large with 32-bit file pointers.