### PR TITLE
Add `--json-status-fd` option to show command exit code.

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,7 +80,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..38"
+echo "1..39"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -139,6 +139,14 @@ echo "ok - all expected devices were created"
 $RUN --unshare-pid --as-pid-1 --bind / / bash -c 'echo $$' > as_pid_1.txt
 assert_file_has_content as_pid_1.txt "1"
 echo "ok - can run as pid 1"
+
+# Test --info-fd and --json-status-fd
+if $RUN --unshare-all --info-fd 42 --json-status-fd 43 -- bash -c 'exit 42' 42>info.json 43>json-status.json 2>err.txt; then
+    fatal "should have been exit 42"
+fi
+assert_file_has_content info.json '"child-pid": [0-9]'
+assert_file_has_content json-status.json '"child-pid": [0-9]'
+echo "ok info and json-status fd"
 
 # These tests require --unshare-user
 if test -n "${bwrap_is_suid:-}"; then


### PR DESCRIPTION
This builds on the work and commentary in https://github.com/projectatomic/bubblewrap/pull/286 to solve https://github.com/projectatomic/bubblewrap/issues/257.

The big changes since then are:
1.  As requested, rather than having a separate option for new information there's an option for showing all the information.
2.  Just reporting the exit code of the subprocess isn't sufficient to distinguish between the exit code of bubblewrap (which may have been due to a sandboxing failure) and the exit code of the command, since there's more set-up performed in the subprocess.

    To solve this a pipe was added to communicate the state by what data is in it when it is closed.

    *   No data if the subprocess terminated before exec.
    *   1 byte if the subprocess terminated after a successful exec.
    *   2 bytes if the subprocess terminated after a failed exec.

    An eventfd was considered instead of a pipe, but it seemed perverse to use IPC intended for events when the only event we care about is end of file.

---
Fixes https://github.com/projectatomic/bubblewrap/issues/257
Obsoletes https://github.com/projectatomic/bubblewrap/pull/268
Obsoletes https://github.com/projectatomic/bubblewrap/pull/286