### PR TITLE
ci: Bump to fedora/29/atomic

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -19,10 +19,10 @@ timeout: 30m
 inherit: true
 
 host:
-    distro: fedora/27/atomic
+    distro: fedora/29/atomic
 
-context: f27-sanitizer
+context: f29-sanitizer
 required: true
 
 tests:
-  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2' ./ci/papr.sh registry.fedoraproject.org/fedora:27
+  - env CFLAGS='-g -Og -fsanitize=undefined -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2' ./ci/papr.sh registry.fedoraproject.org/fedora:29


### PR DESCRIPTION
Fedora 27 has been EOL for a while now... bump it to 29.

It'd be nice to test against FCOS, though it's not currently supported
by PAPR. It's in maintenance mode, but I might add support for it as a
stopgap. Medium-term though, I want to deprecate PAPR in favour of other
CI solutions.

Anyway, for now hopefully this should fix the CI on this repo.